### PR TITLE
Fixed issue where `geometry()` would fail with empty polygons

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -51,6 +51,7 @@ from tests.utils import line_count_equal, line_exists
                 [0, 3, 1 + 2j, 0],
             ],
         ],
+        [Point(0, 0).buffer(1).intersection(Point(10, 10).buffer(1)), []],
     ],
 )
 def test_geometry_single_path(vsk, data, expected):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,18 +35,22 @@ def line_count_equal(vsk: vsketch.Vsketch, *args: Union[int, Tuple[int, int]]) -
         args (int or Tuple[int, int]): line number for each layer
     """
 
-    target_layer_counts = set()
+    target_layer_counts = {}
     for i, p in enumerate(args):
 
         if isinstance(p, int):
-            desc = (i + 1, p)
+            target_layer_counts[i + 1] = p
         else:
-            desc = p
-        target_layer_counts.add(desc)
+            target_layer_counts[p[0]] = p[1]
 
-    actual_layer_counts = set()
+    actual_layer_counts = {}
     for layer_id, layer in vsk.vector_data.layers.items():
-        actual_layer_counts.add((layer_id, len(layer)))
+        actual_layer_counts[layer_id] = len(layer)
+
+    # this is needed when some layer are explicitly specified to 0
+    for k in target_layer_counts:
+        if k not in actual_layer_counts:
+            actual_layer_counts[k] = 0
 
     return target_layer_counts == actual_layer_counts
 

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -878,6 +878,8 @@ class Vsketch:
         Args:
             shape (Shapely geometry): a supported shapely geometry object
         """
+        if getattr(shape, "is_empty", False):
+            return
 
         try:
             if shape.geom_type in ["LineString", "LinearRing"]:


### PR DESCRIPTION
#### Description

...

#### Checklist

- [x] feature/fix implemented
- [x] `mypy vsketch tests` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated and freshly executed in Jupyter ("Reload kernel and run all cells")
- [x] code formatting ok (`black` and `isort`)
