### PR TITLE
Resolve #26

### DIFF
--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -13,11 +13,11 @@ from .utils import line_count_equal, line_exists
     [
         [[(0, 0), (1, 2), (3, 2)], (0, 1 + 2j, 3 + 2j)],
         [[[0, 0], [1, 2], [3, 2]], (0, 1 + 2j, 3 + 2j)],
-        # extra coords must be ignored
-        [[[0, 0, 4], [1, 2, 3, 2], [3, 2]], (0, 1 + 2j, 3 + 2j)],
         [np.array([(3, 2), (4, 3), (1, 2)]), (3 + 2j, 4 + 3j, 1 + 2j)],
         # pure iterable should be accepted
         [zip([3, 2, 4], [3, 5, 7]), (3 + 3j, 2 + 5j, 4 + 7j)],
+        # one complex arg should be accepted
+        [np.array([3 + 3j, 2 + 5j, 4 + 7j]), (3 + 3j, 2 + 5j, 4 + 7j)],
     ],
 )
 def test_polygon_1arg_success(

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -903,11 +903,17 @@ class Vsketch:
         """
         if y is None:
             try:
-                # noinspection PyTypeChecker
-                line = np.array(
-                    [complex(c[0], c[1]) for c in cast(Iterable[Sequence[float]], x)],
-                    dtype=complex,
-                )
+                if hasattr(x, "__len__"):
+                    data = np.array(x)
+                else:
+                    data = np.array(list(x))
+
+                if len(data.shape) == 1 and data.dtype == complex:
+                    line = data
+                elif len(data.shape) == 2 and data.shape[1] == 2:
+                    line = data[:, 0] + 1j * data[:, 1]
+                else:
+                    raise ValueError()
             except:
                 raise ValueError(
                     "when Y is not provided, X must contain an iterable of size 2+ sequences"
@@ -921,6 +927,7 @@ class Vsketch:
                 raise ValueError(
                     "when both X and Y are provided, they must be sequences o float"
                 )
+
 
         hole_lines = []
         try:


### PR DESCRIPTION
#### Description

polygon() now accepts 1 complex iterable as input. Extra coordinates are no longer ignored.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy vsketch tests` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated and freshly executed in Jupyter ("Reload kernel and run all cells")
- [ ] code formatting ok (`black` and `isort`)
