### PR TITLE
Sketch class refactoring (breaking change)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,11 +96,16 @@ napoleon_include_init_with_doc = True
 def autodoc_skip_member(app, what, name, obj, skip, options):
 
     exclusions = (
-        # vsketch/vsketch.py
+        # vsketch/param.py
         "get_params",
         "set_param_set",
         "params",
         "param_set",
+        # misc from vsk
+        "working_directory",
+        "execute",
+        "execute_draw",
+        "ensure_finalized",
     )
     is_private = name.startswith("_") and name != "__init__"
     exclude = name in exclusions or is_private

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -112,35 +112,47 @@ paragraphs provides an overview of how a sketch is made.
 Sketch structure
 ----------------
 
-Sketch scripts always have the same structure::
+Sketch scripts are used by the ``vsk`` CLI tool. They always have the same structure::
 
     import vsketch
 
-    class MySketch(vsketch.Vsketch):
-        def draw(self) -> None:
-            self.size("a4", landscape=False)
+    class MySketch(vsketch.SketchClass):
+        def draw(self, vsk: vsketch.Vsketch) -> None:
+            vsk.size("a4", landscape=False)
 
-        def finalize(self) -> None:
-            self.vpype("linemerge linesimplify reloop linesort")
+        def finalize(self, vsk: vsketch.Vsketch) -> None:
+            vsk.vpype("linemerge linesimplify reloop linesort")
 
 
     if __name__ == "__main__":
-        vsk = MySketch()
-        vsk.draw()
-        vsk.finalize()
-        vsk.display(mode="matplotlib")
+        MySketch().display()
 
-This structure is typically created using the ``vsk init`` command.
+This skeleton is generally created using the ``vsk init`` command.
 
-Your sketch is encapsulated in a subclass of :class:`Vsketch` which must implement two functions:
+Your sketch is encapsulated in a subclass of :class:`SketchClass` which must implement two functions:
 
-    * :meth:`Vsketch.draw` implements the bulk of the sketch's content.
-    * :meth:`Vsketch.finalize` implements the potentially CPU-heavy optimisations that are not required for
+    * :meth:`SketchClass.draw` implements the bulk of the sketch's content.
+    * :meth:`SketchClass.finalize` implements the potentially CPU-heavy optimisations that are not required for
       display purposes.
 
-For display purposes, ``vsk`` only calls :meth:`Vsketch.draw()`. However, when it exports a sketch to a SVG file, it
-also calls :meth:`Vsketch.finalize`. This enables a fast refresh of the display when the sketch or its parameters change
-while ensuring that any SVG output is ready to plot.
+For display purposes, ``vsk`` only calls :meth:`SketchClass.draw`. However, when it exports a sketch to a SVG file, it
+also calls :meth:`SketchClass.finalize`. This enables a fast refresh of the display when the sketch or its parameters
+change while ensuring that any SVG output is ready to plot.
+
+
+Using *vsketch* as a regular package
+------------------------------------
+
+*vsketch* can also be used as a regular Python package, without relying on the ``vsk`` CLI tool. This is useful to
+work, for example, in Jupyter or Colab notebooks.
+
+This is done by simply creating an instance of :class:`vsketch.Vsketch`::
+
+    import vsketch
+
+    vsk = vsketch.Vsketch()
+    vsk.size("a4", landscape=True)
+    # ...
 
 
 Primitives
@@ -148,14 +160,14 @@ Primitives
 
 The usual primitives are available::
 
-    self.line(0, 0, 10, 20)
-    self.rect(10, 10, 5, 8)
-    self.circle(2, 2, radius=3)
-    self.triangle(0, 0, 1, 1, 0, 1)
+    vsk.line(0, 0, 10, 20)
+    vsk.rect(10, 10, 5, 8)
+    vsk.circle(2, 2, radius=3)
+    vsk.triangle(0, 0, 1, 1, 0, 1)
 
 So are the less usual primitives::
 
-    self.bezier(1, 1, 3, 1, 3, 3, 1, 3)
+    vsk.bezier(1, 1, 3, 1, 3, 3, 1, 3)
 
 
 Units
@@ -164,8 +176,8 @@ Units
 By default, vsketch uses CSS pixels as unit, just like SVG. If you'd rather work in some other unit,
 just start your sketch with a scale factor::
 
-    self.scale("1cm")
-    self.line(0, 0, 21, 29.7)  # this line will span an entire A4 page
+    vsk.scale("1cm")
+    vsk.line(0, 0, 21, 29.7)  # this line will span an entire A4 page
 
 
 Strokes, fills and layers
@@ -175,21 +187,21 @@ Colors do not really make sense when preparing files for plotters. *vsketch* ins
 intended to be plotted with different pens each::
 
     # by default, layer 1 is current
-    self.line(0, 0, 5, 5)
+    vsk.line(0, 0, 5, 5)
 
     # the current layer can be changed
-    self.stroke(2)
-    self.circle(14, 8, 3)
+    vsk.stroke(2)
+    vsk.circle(14, 8, 3)
 
 No reason plotters should miss on the "fill" party! This works just as you didn't dare to expect::
 
     # let's use a pen width of 0.5mm for layer 2
-    self.penWidth("0.5mm", 2)
+    vsk.penWidth("0.5mm", 2)
 
     # this circle will be stroked in layer 1 and and filled in layer 2
-    self.stroke(1)
-    self.fill(2)
-    self.circle(0, 0, 5)
+    vsk.stroke(1)
+    vsk.fill(2)
+    vsk.circle(0, 0, 5)
 
 
 Using Shapely
@@ -200,7 +212,7 @@ very useful for generative plotter art. *vsketch* directly accepts Shapely objec
 
     from shapely.geometry import Point
 
-    self.geometry(Point(0, 0).buffer(2).union(Point(1.5, 0).buffer(1.5)))
+    vsk.geometry(Point(0, 0).buffer(2).union(Point(1.5, 0).buffer(1.5)))
 
 
 Transforms
@@ -210,23 +222,23 @@ Transformation matrices are fully supported::
 
     for i in range(5):
         with pushMatrix():
-            self.rotate(i * 5, degrees=True)
-            self.rect(-2, -2, 2, 2)
+            vsk.rotate(i * 5, degrees=True)
+            vsk.rect(-2, -2, 2, 2)
 
-        self.translate(5, 0)
+        vsk.translate(5, 0)
 
 Internally, vsketch approximates all curves with segments. The level of detail (i.e. the maximum length of individual
 segment) can be adjusted. *vsketch* tries to be smart about this::
 
-    self.detail("0.1mm")
+    vsk.detail("0.1mm")
 
     # this circle is made of segment 0.1mm-long or less
-    self.circle(0, 0, radius=1)
+    vsk.circle(0, 0, radius=1)
 
-    self.scale(100)
+    vsk.scale(100)
 
     # because it is bigger, this circle will be made of many more segments than the previous one
-    self.circle(0, 0, radius=1)
+    vsk.circle(0, 0, radius=1)
 
 
 Perlin noise
@@ -237,9 +249,9 @@ This example illustrate the case of a vectorised sampling of a 2D noise space::
 
     num_lines = 250
     x_coords = np.linspace(0., 250., 1000)
-    perlin = self.noise(x_coords * 0.1, np.linspace(0, 5., num_lines))
+    perlin = vsk.noise(x_coords * 0.1, np.linspace(0, 5., num_lines))
     for j in range(num_lines):
-        self.polygon(x_coords, j + perlin[:, j] * 6)
+        vsk.polygon(x_coords, j + perlin[:, j] * 6)
 
 
 Using sub-sketches
@@ -253,39 +265,31 @@ Multiple sketches can be created and used as reusable sub-sketches::
     sub_sketch.square(0.5, 0.5, 1)
 
     # add the sub-sketch
-    self.sketch(sub_sketch)
-    self.translate(10, 10)
-    self.rotate(45, degrees=True)
-    self.sketch(sub_sketch)  # the transformation matrix is applied on the sub-sketch
+    vsk.sketch(sub_sketch)
+    vsk.translate(10, 10)
+    vsk.rotate(45, degrees=True)
+    vsk.sketch(sub_sketch)  # the transformation matrix is applied on the sub-sketch
 
 Using *vpype*
 -------------
 
 The power of `vpype`_ can be unleashed with a single call::
 
-    self.vpype("linesimplify linemerge reloop linesort")
+    vsk.vpype("linesimplify linemerge reloop linesort")
 
 Displaying and saving
 ---------------------
 
-Usually, ``vsk`` takes care of running, displaying and exporting your sketch as SVG. This is also easy to do from a
-regular script. Displaying is done as follows::
+``vsk`` generally takes care of running, displaying and exporting your sketch as SVG. When using *vsketch* as a
+standalone package, this must be done manually.
 
-    self.display()
+Displaying is done as follows::
 
-Finally, you can save a ready-to-plot SVG::
+    vsk.display()
 
-    self.save("my_file.svg")
+And saving a ready-to-plot SVG as follows::
 
-As a matter of fact, examples always includes the following code::
-
-    if __name__ == "__main__":
-        vsk = MySketch()
-        vsk.draw()
-        vsk.finalize()
-        vsk.display()
-
-This way, the sketch can be executed by Python without having to use the ``vsk`` command.
+    vsk.save("my_file.svg")
 
 
 Beyond the basics?

--- a/examples/bezier_bugs/sketch_bezier_bugs.py
+++ b/examples/bezier_bugs/sketch_bezier_bugs.py
@@ -33,27 +33,24 @@ def bug(vsk, x, y):
             vsk.bezier(x1, y1, x2, y2, x3, y3, x4, y4)
 
 
-class BezierBugSketch(vsketch.Vsketch):
+class BezierBugSketch(vsketch.SketchClass):
     row_count = vsketch.Param(7, 1)
     column_count = vsketch.Param(7, 1)
     row_offset = vsketch.Param(100.0)
     column_offset = vsketch.Param(100.0)
 
-    def draw(self) -> None:
-        self.size("10in", "10in")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("10in", "10in")
 
         for row in range(self.row_count):
             for col in range(self.column_count):
                 x = col * self.column_offset
                 y = row * self.row_offset
-                bug(self, x, y)
+                bug(vsk, x, y)
 
-    def finalize(self) -> None:
-        self.vpype("linesimplify linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linesimplify linesort")
 
 
 if __name__ == "__main__":
-    vsk = BezierBugSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    BezierBugSketch.display()

--- a/examples/detail/sketch_detail.py
+++ b/examples/detail/sketch_detail.py
@@ -1,35 +1,32 @@
 import vsketch
 
 
-class DetailSketch(vsketch.Vsketch):
+class DetailSketch(vsketch.SketchClass):
     detail_value = vsketch.Param(1, 1, 50, unit="mm")
 
-    def draw(self) -> None:
-        self.size("a5", landscape=True)
-        self.scale("1.5cm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a5", landscape=True)
+        vsk.scale("1.5cm")
 
-        self.detail(self.detail_value)
+        vsk.detail(self.detail_value)
 
-        self.circle(0, 0, 1)
-        self.circle(0, 0, 2)
-        with self.pushMatrix():
-            self.scale(4)
+        vsk.circle(0, 0, 1)
+        vsk.circle(0, 0, 2)
+        with vsk.pushMatrix():
+            vsk.scale(4)
             # the scale is taken into account to compute details
-            self.circle(0, 0, 1)
+            vsk.circle(0, 0, 1)
 
-        self.translate(4, 0)
+        vsk.translate(4, 0)
 
         for i in range(-4, 5):
-            with self.pushMatrix():
-                self.translate(0, i * 0.4)
-                self.bezier(0, 0, 1, -2, 2, 2, 3, 0)
+            with vsk.pushMatrix():
+                vsk.translate(0, i * 0.4)
+                vsk.bezier(0, 0, 1, -2, 2, 2, 3, 0)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = DetailSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    DetailSketch.display()

--- a/examples/noise_bezier/sketch_noise_bezier.py
+++ b/examples/noise_bezier/sketch_noise_bezier.py
@@ -3,21 +3,21 @@ import numpy as np
 import vsketch
 
 
-class NoiseBezierSketch(vsketch.Vsketch):
+class NoiseBezierSketch(vsketch.SketchClass):
     N = vsketch.Param(200, 0)
     freq = vsketch.Param(0.003, decimals=3)
     drift = vsketch.Param(0.06, decimals=2)
 
-    def draw(self) -> None:
-        self.size("a4", landscape=False)
-        self.scale("cm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=False)
+        vsk.scale("cm")
 
         t = np.arange(self.N) * self.freq
-        perlin = self.noise(t, np.arange(8) * 1000)
+        perlin = vsk.noise(t, np.arange(8) * 1000)
 
         for i in range(self.N):
             v = i * self.drift
-            self.bezier(
+            vsk.bezier(
                 perlin[i, 0] * 10 + v,
                 perlin[i, 1] * 10 + v,
                 perlin[i, 2] * 10 + v,
@@ -28,12 +28,9 @@ class NoiseBezierSketch(vsketch.Vsketch):
                 perlin[i, 7] * 10 + v,
             )
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = NoiseBezierSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    NoiseBezierSketch.display()

--- a/examples/point_transform/sketch_point_transform.py
+++ b/examples/point_transform/sketch_point_transform.py
@@ -1,35 +1,32 @@
 import vsketch
 
 
-class PointTransformSketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=False)
-        self.scale("1mm")
+class PointTransformSketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=False)
+        vsk.scale("1mm")
 
-        with self.pushMatrix():
+        with vsk.pushMatrix():
             for _ in range(40):
-                self.rotate(2, degrees=True)
-                self.scale(0.95)
-                self.point(-75, 75)
-                self.point(0, 75)
-                self.point(75, 75)
-                self.point(75, 0)
-                self.point(75, -75)
-                self.point(0, -75)
-                self.point(-75, -75)
-                self.point(-75, 0)
+                vsk.rotate(2, degrees=True)
+                vsk.scale(0.95)
+                vsk.point(-75, 75)
+                vsk.point(0, 75)
+                vsk.point(75, 75)
+                vsk.point(75, 0)
+                vsk.point(75, -75)
+                vsk.point(0, -75)
+                vsk.point(-75, -75)
+                vsk.point(-75, 0)
 
-        with self.pushMatrix():
-            self.rotate(80, degrees=True)
-            self.scale(0.95 ** 40)
-            self.square(0, 0, 150, mode="center")
+        with vsk.pushMatrix():
+            vsk.rotate(80, degrees=True)
+            vsk.scale(0.95 ** 40)
+            vsk.square(0, 0, 150, mode="center")
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = PointTransformSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    PointTransformSketch.display()

--- a/examples/polygons/sketch_polygons.py
+++ b/examples/polygons/sketch_polygons.py
@@ -3,22 +3,19 @@ import numpy as np
 import vsketch
 
 
-class PolygonsSketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("4mm")
+class PolygonsSketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("4mm")
 
         phase = -np.pi / 2
         for i in range(20):
             angles = np.linspace(0, 2 * np.pi, i + 4)
-            self.polygon((i + 1) * np.cos(angles + phase), (i + 1) * np.sin(angles + phase))
+            vsk.polygon((i + 1) * np.cos(angles + phase), (i + 1) * np.sin(angles + phase))
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = PolygonsSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    PolygonsSketch.display()

--- a/examples/prime_circles/sketch_prime_circles.py
+++ b/examples/prime_circles/sketch_prime_circles.py
@@ -15,16 +15,17 @@ def get_primes(n):
     return primes
 
 
-class PrimeCirclesSketch(vsketch.Vsketch):
-    N = vsketch.Param(100, 0)
+class PrimeCirclesSketch(vsketch.SketchClass):
+    N = vsketch.Param(100, 1)
     random_phase = vsketch.Param(False)
 
-    def draw(self) -> None:
-        self.size("10in", "10in")
-        self.scale("3mm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("10in", "10in")
+        vsk.scale("3mm")
 
+        i = 0
         for i, prime in enumerate(get_primes(self.N)):
-            self.circle(0, 0, 2 * (i + 1))
+            vsk.circle(0, 0, 2 * (i + 1))
 
             if self.random_phase:
                 phase = np.random.random() * 2 * math.pi
@@ -32,21 +33,18 @@ class PrimeCirclesSketch(vsketch.Vsketch):
                 phase = -math.pi / 2
 
             for angle in np.linspace(0, 2 * math.pi, prime, endpoint=False):
-                self.line(
+                vsk.line(
                     (i + 1) * math.cos(angle + phase),
                     (i + 1) * math.sin(angle + phase),
                     (i + 2) * math.cos(angle + phase),
                     (i + 2) * math.sin(angle + phase),
                 )
 
-        self.circle(0, 0, 2 * (i + 2))
+        vsk.circle(0, 0, 2 * (i + 2))
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = PrimeCirclesSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    PrimeCirclesSketch.display()

--- a/examples/quick_draw/sketch_quick_draw.py
+++ b/examples/quick_draw/sketch_quick_draw.py
@@ -406,7 +406,7 @@ def quickdraw_to_linestring(qd_image):
     return MultiLineString(linestrings)
 
 
-class QuickDrawSketch(vsketch.Vsketch):
+class QuickDrawSketch(vsketch.SketchClass):
     category = vsketch.Param("crab", choices=quick_draw_categories)
     page_size = vsketch.Param("a4", choices=vp.PAGE_SIZES.keys())
     landscape = vsketch.Param(False)
@@ -416,9 +416,9 @@ class QuickDrawSketch(vsketch.Vsketch):
     rows = vsketch.Param(13, 1)
     scale_factor = vsketch.Param(3.0)
 
-    def draw(self) -> None:
-        self.size(self.page_size, landscape=self.landscape)
-        self.penWidth("0.5mm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size(self.page_size, landscape=self.landscape)
+        vsk.penWidth("0.5mm")
 
         # obtain the datafile
         file_name = self.category + ".bin"
@@ -434,30 +434,27 @@ class QuickDrawSketch(vsketch.Vsketch):
 
         # draw stuff
 
-        width = self.width - 2 * self.margins
-        height = self.height - 2 * self.margins
+        width = vsk.width - 2 * self.margins
+        height = vsk.height - 2 * self.margins
 
         n = self.columns * self.rows
         samples = random.sample(drawing_subset, n)
         for j in range(self.rows):
-            with self.pushMatrix():
+            with vsk.pushMatrix():
                 for i in range(self.columns):
                     idx = j * self.columns + i
-                    with self.pushMatrix():
-                        self.scale(self.scale_factor * min(1 / self.columns, 1 / self.rows))
+                    with vsk.pushMatrix():
+                        vsk.scale(self.scale_factor * min(1 / self.columns, 1 / self.rows))
                         drawing = quickdraw_to_linestring(samples[idx])
-                        self.stroke((idx % self.layer_count) + 1)
-                        self.geometry(drawing)
-                    self.translate(width / self.columns, 0)
+                        vsk.stroke((idx % self.layer_count) + 1)
+                        vsk.geometry(drawing)
+                    vsk.translate(width / self.columns, 0)
 
-            self.translate(0, height / self.rows)
+            vsk.translate(0, height / self.rows)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesort")
 
 
 if __name__ == "__main__":
-    vsk = QuickDrawSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    QuickDrawSketch.display()

--- a/examples/random_flower/sketch_random_flower.py
+++ b/examples/random_flower/sketch_random_flower.py
@@ -5,38 +5,35 @@ import numpy as np
 import vsketch
 
 
-class RandomFlowerSketch(vsketch.Vsketch):
+class RandomFlowerSketch(vsketch.SketchClass):
     num_line = vsketch.Param(200, 1)
     point_per_line = vsketch.Param(100, 1)
     rdir_range = vsketch.Param(math.pi / 6)
 
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("cm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("cm")
 
-        self.rotate(-90, degrees=True)
+        vsk.rotate(-90, degrees=True)
 
         noise_coord = np.linspace(0, 1, self.point_per_line)
         dirs = np.linspace(0, 2 * math.pi, self.num_line)
-        perlin = self.noise(noise_coord, dirs, [0, 100])
+        perlin = vsk.noise(noise_coord, dirs, [0, 100])
 
         for i, direction in enumerate(dirs):
-            rdir = self.map(
+            rdir = vsk.map(
                 perlin[:, i, 0], 0, 1, direction - self.rdir_range, direction + self.rdir_range
             )
-            roffset = self.map(perlin[:, i, 1], 0, 1, 0.05, 0.12)
+            roffset = vsk.map(perlin[:, i, 1], 0, 1, 0.05, 0.12)
 
             xoffset = roffset * np.cos(rdir)
             yoffset = roffset * np.sin(rdir)
 
-            self.polygon(np.cumsum(xoffset), np.cumsum(yoffset))
+            vsk.polygon(np.cumsum(xoffset), np.cumsum(yoffset))
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = RandomFlowerSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    RandomFlowerSketch.display()

--- a/examples/random_lines/sketch_random_lines.py
+++ b/examples/random_lines/sketch_random_lines.py
@@ -3,32 +3,29 @@ import numpy as np
 import vsketch
 
 
-class RandomLinesSketch(vsketch.Vsketch):
+class RandomLinesSketch(vsketch.SketchClass):
     num_line = vsketch.Param(200, 1)
     y_offset = vsketch.Param(18.0)
     x_freq = vsketch.Param(0.25)
     y_freq = vsketch.Param(4)
 
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("cm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("cm")
 
         x_coords = np.linspace(0, 25, 1000)
 
-        perlin = self.noise(
+        perlin = vsk.noise(
             x_coords * self.x_freq, np.arange(self.num_line) / self.num_line * self.y_freq
         )
 
         for i in range(self.num_line):
             y_coords = perlin[:, i] + self.y_offset / self.num_line * i
-            self.polygon(x_coords, y_coords)
+            vsk.polygon(x_coords, y_coords)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = RandomLinesSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    RandomLinesSketch.display()

--- a/examples/schotter/sketch_schotter.py
+++ b/examples/schotter/sketch_schotter.py
@@ -1,34 +1,31 @@
 import vsketch
 
 
-class SchotterSketch(vsketch.Vsketch):
+class SchotterSketch(vsketch.SketchClass):
     columns = vsketch.Param(12)
     rows = vsketch.Param(22)
     fuzziness = vsketch.Param(1.0)
 
-    def draw(self) -> None:
-        self.size("a4", landscape=False)
-        self.scale("cm")
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=False)
+        vsk.scale("cm")
 
         for j in range(self.rows):
-            with self.pushMatrix():
+            with vsk.pushMatrix():
                 for i in range(self.columns):
-                    with self.pushMatrix():
-                        self.rotate(self.fuzziness * 0.03 * self.random(-j, j))
-                        self.translate(
-                            self.fuzziness * 0.01 * self.randomGaussian() * j,
-                            self.fuzziness * 0.01 * self.randomGaussian() * j,
+                    with vsk.pushMatrix():
+                        vsk.rotate(self.fuzziness * 0.03 * vsk.random(-j, j))
+                        vsk.translate(
+                            self.fuzziness * 0.01 * vsk.randomGaussian() * j,
+                            self.fuzziness * 0.01 * vsk.randomGaussian() * j,
                         )
-                        self.rect(0, 0, 1, 1)
-                    self.translate(1, 0)
-            self.translate(0, 1)
+                        vsk.rect(0, 0, 1, 1)
+                    vsk.translate(1, 0)
+            vsk.translate(0, 1)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = SchotterSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    SchotterSketch.display()

--- a/examples/shapely/sketch_shapely.py
+++ b/examples/shapely/sketch_shapely.py
@@ -6,10 +6,10 @@ from shapely.ops import unary_union
 import vsketch
 
 
-class ShapelySketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=False)
-        self.scale("4mm")
+class ShapelySketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=False)
+        vsk.scale("4mm")
 
         for i in range(5):
             for j in range(7):
@@ -19,14 +19,11 @@ class ShapelySketch(vsketch.Vsketch):
                         for _ in range(15)
                     ]
                 )
-                self.geometry(translate(shape, i * 8, j * 8))
+                vsk.geometry(translate(shape, i * 8, j * 8))
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = ShapelySketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    ShapelySketch.display()

--- a/examples/stroke_fill/sketch_stroke_fill.py
+++ b/examples/stroke_fill/sketch_stroke_fill.py
@@ -4,11 +4,11 @@ from shapely.geometry import Polygon
 import vsketch
 
 
-class StrokeFillSketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("1cm")
-        self.penWidth("0.5mm")
+class StrokeFillSketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("1cm")
+        vsk.penWidth("0.5mm")
 
         p = translate(
             Polygon(
@@ -20,45 +20,42 @@ class StrokeFillSketch(vsketch.Vsketch):
         )
 
         # the default is no fill and stroke to layer 1
-        self.square(0, 0, 4)
-        self.circle(2, 8, 4)
-        self.geometry(p)
+        vsk.square(0, 0, 4)
+        vsk.circle(2, 8, 4)
+        vsk.geometry(p)
 
-        self.translate(7, 0)
+        vsk.translate(7, 0)
 
         # add some fill to layer 2
-        self.fill(2)
-        self.penWidth("1mm", 2)
-        self.square(0, 0, 4)
-        self.circle(2, 8, 4)
-        self.geometry(p)
+        vsk.fill(2)
+        vsk.penWidth("1mm", 2)
+        vsk.square(0, 0, 4)
+        vsk.circle(2, 8, 4)
+        vsk.geometry(p)
 
-        self.translate(7, 0)
+        vsk.translate(7, 0)
 
         # with thick stroke
-        self.fill(2)
-        self.penWidth("1mm", 2)
-        self.strokeWeight(4)
-        self.square(0, 0, 4)
-        self.circle(2, 8, 4)
-        self.geometry(p)
+        vsk.fill(2)
+        vsk.penWidth("1mm", 2)
+        vsk.strokeWeight(4)
+        vsk.square(0, 0, 4)
+        vsk.circle(2, 8, 4)
+        vsk.geometry(p)
 
-        self.translate(7, 0)
+        vsk.translate(7, 0)
 
         # remove stroke and set fill to layer 3 with a thicker pen
-        self.fill(3)
-        self.penWidth("2mm", 3)
-        self.noStroke()
-        self.square(0, 0, 4)
-        self.circle(2, 8, 4)
-        self.geometry(p)
+        vsk.fill(3)
+        vsk.penWidth("2mm", 3)
+        vsk.noStroke()
+        vsk.square(0, 0, 4)
+        vsk.circle(2, 8, 4)
+        vsk.geometry(p)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = StrokeFillSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    StrokeFillSketch.display()

--- a/examples/subsketch/sketch_subsketch.py
+++ b/examples/subsketch/sketch_subsketch.py
@@ -1,10 +1,10 @@
 import vsketch
 
 
-class SubSketchSketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("cm")
+class SubSketchSketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("cm")
 
         # create a stick figure
         sub = vsketch.Vsketch()
@@ -17,19 +17,16 @@ class SubSketchSketch(vsketch.Vsketch):
         sub.line(1, 2, 1.3, 4)
 
         for i in range(8):
-            with self.pushMatrix():
-                self.scale(0.95 ** i)
-                self.rotate(8 * i, degrees=True)
-                self.sketch(sub)
+            with vsk.pushMatrix():
+                vsk.scale(0.95 ** i)
+                vsk.rotate(8 * i, degrees=True)
+                vsk.sketch(sub)
 
-            self.translate(3, 0)
+            vsk.translate(3, 0)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = SubSketchSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    SubSketchSketch.display()

--- a/examples/transforms/sketch_transforms.py
+++ b/examples/transforms/sketch_transforms.py
@@ -3,10 +3,10 @@ import numpy as np
 import vsketch
 
 
-class TransformsSketch(vsketch.Vsketch):
-    def draw(self) -> None:
-        self.size("a4", landscape=True)
-        self.scale("2cm")
+class TransformsSketch(vsketch.SketchClass):
+    def draw(self, vsk: vsketch.Vsketch) -> None:
+        vsk.size("a4", landscape=True)
+        vsk.scale("2cm")
 
         # build a star
         angles = np.linspace(0, 2 * np.pi, 5, endpoint=False)
@@ -14,29 +14,26 @@ class TransformsSketch(vsketch.Vsketch):
         x = np.cos(angles[idx] - np.pi / 2)
         y = np.sin(angles[idx] - np.pi / 2)
 
-        with self.pushMatrix():
+        with vsk.pushMatrix():
             for i in range(5):
-                with self.pushMatrix():
-                    self.scale(0.8 ** i)
-                    self.polygon(x, y)
+                with vsk.pushMatrix():
+                    vsk.scale(0.8 ** i)
+                    vsk.polygon(x, y)
 
-                self.translate(2, 0)
+                vsk.translate(2, 0)
 
-        self.translate(0, 4)
+        vsk.translate(0, 4)
 
         for i in range(5):
-            with self.pushMatrix():
-                self.rotate(i * 4, degrees=True)
-                self.polygon(x, y)
+            with vsk.pushMatrix():
+                vsk.rotate(i * 4, degrees=True)
+                vsk.polygon(x, y)
 
-            self.translate(2, 0)
+            vsk.translate(2, 0)
 
-    def finalize(self) -> None:
-        self.vpype("linemerge linesimplify reloop linesort")
+    def finalize(self, vsk: vsketch.Vsketch) -> None:
+        vsk.vpype("linemerge linesimplify reloop linesort")
 
 
 if __name__ == "__main__":
-    vsk = TransformsSketch()
-    vsk.draw()
-    vsk.finalize()
-    vsk.display()
+    TransformsSketch.display()

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "anyio"
-version = "2.1.0"
+version = "2.2.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = true
@@ -22,7 +22,7 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 [package.extras]
 curio = ["curio (>=1.4)"]
 doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "trustme", "uvloop"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -60,14 +60,15 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
 name = "arrow"
-version = "0.17.0"
+version = "1.0.3"
 description = "Better dates & times for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 python-dateutil = ">=2.7.0"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "atomicwrites"
@@ -287,7 +288,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 
 [[package]]
 name = "defusedxml"
-version = "0.6.0"
+version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
 category = "main"
 optional = false
@@ -322,7 +323,7 @@ python-versions = ">=2.7"
 
 [[package]]
 name = "glcontext"
-version = "2.3.2"
+version = "2.3.3"
 description = "Portable OpenGL Context"
 category = "main"
 optional = false
@@ -346,7 +347,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.7.0"
+version = "3.7.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -401,7 +402,7 @@ matplotlib = ">=2.0.0"
 
 [[package]]
 name = "ipython"
-version = "7.20.0"
+version = "7.21.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
@@ -459,7 +460,7 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 
 [[package]]
 name = "isort"
-version = "5.7.0"
+version = "5.8.0"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
@@ -558,7 +559,7 @@ qtconsole = "*"
 
 [[package]]
 name = "jupyter-client"
-version = "6.1.11"
+version = "6.1.12"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = false
@@ -573,11 +574,11 @@ traitlets = "*"
 
 [package.extras]
 doc = ["sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["jedi (<=0.17.2)", "ipykernel", "ipython", "mock", "pytest", "pytest-asyncio", "async-generator", "pytest-timeout"]
+test = ["async-generator", "ipykernel", "ipython", "mock", "pytest-asyncio", "pytest-timeout", "pytest", "jedi (<0.18)"]
 
 [[package]]
 name = "jupyter-console"
-version = "6.2.0"
+version = "6.3.0"
 description = "Jupyter terminal console"
 category = "dev"
 optional = false
@@ -684,7 +685,7 @@ test = ["coverage", "requests", "pytest", "pytest-cov", "pytest-tornasync", "pyt
 
 [[package]]
 name = "jupyterlab"
-version = "3.0.9"
+version = "3.0.12"
 description = "The JupyterLab server extension."
 category = "main"
 optional = true
@@ -707,7 +708,7 @@ test = ["pytest (>=6.0)", "pytest-cov", "pytest-console-scripts", "pytest-check-
 
 [[package]]
 name = "jupyterlab-code-formatter"
-version = "1.4.4"
+version = "1.4.5"
 description = "Code formatter for JupyterLab"
 category = "main"
 optional = true
@@ -808,7 +809,7 @@ dill = ">=0.3.3"
 
 [[package]]
 name = "mypy"
-version = "0.800"
+version = "0.812"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -893,11 +894,11 @@ test = ["check-manifest", "fastjsonschema", "testpath", "pytest", "pytest-cov"]
 
 [[package]]
 name = "notebook"
-version = "6.2.0"
+version = "6.3.0"
 description = "A web-based notebook environment for interactive computing"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 argon2-cffi = "*"
@@ -988,7 +989,7 @@ python-versions = "*"
 
 [[package]]
 name = "pillow"
-version = "8.1.0"
+version = "8.1.2"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = false
@@ -1040,7 +1041,7 @@ twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.16"
+version = "3.0.17"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -1083,7 +1084,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.8.0"
+version = "2.8.1"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -1234,7 +1235,7 @@ python-versions = "~=3.6"
 
 [[package]]
 name = "qtconsole"
-version = "5.0.2"
+version = "5.0.3"
 description = "Jupyter Qt console"
 category = "dev"
 optional = false
@@ -1277,7 +1278,7 @@ sphinx = ">=1.3.1"
 
 [[package]]
 name = "regex"
-version = "2020.11.13"
+version = "2021.3.17"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -1370,7 +1371,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "3.5.1"
+version = "3.5.3"
 description = "Python documentation generator"
 category = "main"
 optional = true
@@ -1501,7 +1502,7 @@ test = ["pytest"]
 
 [[package]]
 name = "svgelements"
-version = "1.4.7"
+version = "1.4.9"
 description = "Svg Elements Parsing"
 category = "main"
 optional = false
@@ -1517,7 +1518,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "terminado"
-version = "0.9.2"
+version = "0.9.3"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
 category = "main"
 optional = false
@@ -1612,20 +1613,20 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.3"
+version = "1.26.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "vpype"
-version = "1.6.0-alpha.0"
+version = "1.7.0-alpha.0"
 description = "The Swiss Army knife of vector graphics for pen plotters"
 category = "main"
 optional = false
@@ -1643,21 +1644,22 @@ moderngl = "^5.6.2"
 multiprocess = "^0.70.11"
 numpy = "^1.20"
 Pillow = "^8.1.0"
+pnoise = "^0.1.0"
 PySide2 = "^5.15.2"
 scipy = "^1.6"
 Shapely = {version = "~1.7.1", extras = ["vectorized"]}
-svgelements = "1.4.7"
+svgelements = "1.4.9"
 svgwrite = "~1.4"
 toml = "~0.10.2"
 
 [package.extras]
-docs = ["Sphinx (>=3.3.0,<4.0.0)", "sphinx-click (>=2.5.0,<3.0.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "recommonmark (>=0.6,<0.8)"]
+docs = ["Sphinx (>=3.3.0,<4.0.0)", "sphinx-click (>=2.5.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "recommonmark (>=0.6,<0.8)"]
 
 [package.source]
 type = "git"
 url = "https://github.com/abey79/vpype"
 reference = "master"
-resolved_reference = "1e245760873b07ba4e92d847eb2ea9b9d6e0a4d9"
+resolved_reference = "4b374c9c1e6cb8fe363a25abf5e3600cc2e96301"
 
 [[package]]
 name = "watchgod"
@@ -1696,15 +1698,15 @@ notebook = ">=4.4.1"
 
 [[package]]
 name = "zipp"
-version = "3.4.0"
+version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 colab = ["requests"]
@@ -1714,7 +1716,7 @@ jupyterlab = ["jupyterlab", "jupyter_nbextensions_configurator", "jupyterlab", "
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, !=3.9.0, <3.10"
-content-hash = "6fbf9fba9f1fe5d1ae4d6feae12f394534b3becb0c421dbc5de44545393f043e"
+content-hash = "188e59caa1a915fafb03c4ea1c3513ea9f1d6e88bf0eb9b4c7c54b43814a938d"
 
 [metadata.files]
 alabaster = [
@@ -1722,8 +1724,8 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 anyio = [
-    {file = "anyio-2.1.0-py3-none-any.whl", hash = "sha256:c286818ccd5dcbd5d385b223f16a055393474527b1d5650da489828a9887d559"},
-    {file = "anyio-2.1.0.tar.gz", hash = "sha256:8a56e08623dc55955a06719d4ad62de6009bb3f1dd04936e60b2104dd58da484"},
+    {file = "anyio-2.2.0-py3-none-any.whl", hash = "sha256:aa3da546ed17f097ca876c78024dea380a3b7fa80759abfdda59f12176a3dac8"},
+    {file = "anyio-2.2.0.tar.gz", hash = "sha256:4a41c5b3a65ed92e469d51b6fba3779301850ea2e352afcf9e36c46f21ee14a9"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1754,8 +1756,8 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
 ]
 arrow = [
-    {file = "arrow-0.17.0-py2.py3-none-any.whl", hash = "sha256:e098abbd9af3665aea81bdd6c869e93af4feb078e98468dd351c383af187aac5"},
-    {file = "arrow-0.17.0.tar.gz", hash = "sha256:ff08d10cda1d36c68657d6ad20d74fbea493d980f8b2d45344e00d6ed2bf6ed4"},
+    {file = "arrow-1.0.3-py3-none-any.whl", hash = "sha256:3515630f11a15c61dcb4cdd245883270dd334c83f3e639824e65a4b79cc48543"},
+    {file = "arrow-1.0.3.tar.gz", hash = "sha256:399c9c8ae732270e1aa58ead835a79a40d7be8aa109c579898eb41029b5a231d"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1882,8 +1884,8 @@ decorator = [
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
 ]
 defusedxml = [
-    {file = "defusedxml-0.6.0-py2.py3-none-any.whl", hash = "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93"},
-    {file = "defusedxml-0.6.0.tar.gz", hash = "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"},
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 dill = [
     {file = "dill-0.3.3-py2.py3-none-any.whl", hash = "sha256:78370261be6ea49037ace8c17e0b7dd06d0393af6513cc23f9b222d9367ce389"},
@@ -1898,30 +1900,30 @@ entrypoints = [
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
 glcontext = [
-    {file = "glcontext-2.3.2-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:8b92a3bcca1cd0be5fa6add8c3feb723747a160b372523c6f720485c7648838d"},
-    {file = "glcontext-2.3.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3c62af1f972f97565deac6d08230bcd3ce09e6ab580b822eebe30dd9c902d19b"},
-    {file = "glcontext-2.3.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:771c36d0a2fc03b94130f46ff996e0f607c72b54fcba72fb7493cf2dd18fe46a"},
-    {file = "glcontext-2.3.2-cp35-cp35m-win32.whl", hash = "sha256:fdf3ae07f8de29b7fa9c6006b5bc6b8fc8e508455574405473f680ecba8272b7"},
-    {file = "glcontext-2.3.2-cp35-cp35m-win_amd64.whl", hash = "sha256:eb35d324239cc42df402b8716f0aa0d7f30d68b895f183f4d4a3f424b3b9579b"},
-    {file = "glcontext-2.3.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:17cf58e4a70897da8a99d72044cf1437e2fd232d4e3af599e018e858e27df6d7"},
-    {file = "glcontext-2.3.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:470474a7b2e963af284c07116dd9b3f7fab0a5195da308f33599fcad1ef5de7f"},
-    {file = "glcontext-2.3.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:842492c39ec7fc87f982300def79751dab7888b985c6f1dab13b5937f56f5a0d"},
-    {file = "glcontext-2.3.2-cp36-cp36m-win32.whl", hash = "sha256:b59ec600fbdd7bffeb22ac96fd1639980fe08a41a5935c9deb0c2012cdd190da"},
-    {file = "glcontext-2.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:4385d2d6626a7f3d33b06eefe5b506bb1c4afc2b2996b9ac8c5ff32d7de2b432"},
-    {file = "glcontext-2.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ecea09f612eed473b5eec2f56b68e3278ce683e7220b2895e5864b6c4ccef87f"},
-    {file = "glcontext-2.3.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:59bf670a5899998ee7190bc5130da025512c765b36b89dcb06477535f67ae882"},
-    {file = "glcontext-2.3.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:eb83051e4246160c1f60943b74accb5fe91835022deb753ffc18e3087d82a011"},
-    {file = "glcontext-2.3.2-cp37-cp37m-win32.whl", hash = "sha256:6257b0319bf05859630c117550d46b71973b591e863bd8b1eb6faec0f51199fe"},
-    {file = "glcontext-2.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7804bc3ef37ba0d35845e02e5e428713857b181bd2826ffc48b863613e40649b"},
-    {file = "glcontext-2.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:eae3ff044064f2b6b5a6023afbccd6751aa6b1c1896dd4bb411e36cc8f64c143"},
-    {file = "glcontext-2.3.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:01632bc0c33e71f57801daacb0f3e552a01a426e1e9cd45dadd969bc66fc0c9c"},
-    {file = "glcontext-2.3.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:e34b8d6f0598d27ce02fb1b535d37827b37259ddc811ec689091d68e9f8df054"},
-    {file = "glcontext-2.3.2-cp38-cp38-win32.whl", hash = "sha256:beeb8aa834773cc3dc1c37809841cfb26be16dfd2dedffdf76a246fb9c92de51"},
-    {file = "glcontext-2.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:dad729ebbb870a725aba7fba75589d3b90e1b495b8d4b4533721b8ea798898f8"},
-    {file = "glcontext-2.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54324b5b5486ca53f83a64410939c08549ee5253845675131b54e57c8f9bc11a"},
-    {file = "glcontext-2.3.2-cp39-cp39-win32.whl", hash = "sha256:44f8c5a07add0b90a46b10e3f328731f51d7ac973047dfada6e0338d3bf3f77e"},
-    {file = "glcontext-2.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:950bdbfad1162ecaee03cdd070ab02b0e0ce4a9efe03708f706bd3c5985f29f7"},
-    {file = "glcontext-2.3.2.tar.gz", hash = "sha256:f716c05689ddf911afe68c7e7e3ac2b283e40a184031d81055141d310f07235e"},
+    {file = "glcontext-2.3.3-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:f518379551a2b60d45c1eec23759cb1ee85517d4b943fc31530b6ab13e304fe4"},
+    {file = "glcontext-2.3.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:d3a8fbc27f43766d168bae02474790459f4050adeb25832ff0a227cc5006c933"},
+    {file = "glcontext-2.3.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aa1d9e4f9bd6eda3d195f39c47c849b3721caf65813a4ad1e006a20fa02d33e4"},
+    {file = "glcontext-2.3.3-cp35-cp35m-win32.whl", hash = "sha256:8b4ee9cb5573e2ae313e1681fdfe2c5ac5b8780b20e857daf8f95e318c36aa2f"},
+    {file = "glcontext-2.3.3-cp35-cp35m-win_amd64.whl", hash = "sha256:b92ca447a04c3a05afb3974a6e94f584e60f55444c3e55ecd31fbfacad6ee07a"},
+    {file = "glcontext-2.3.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b102a00e7bbce03a5e8bb02692197f96fcb77c51dbe133859b70afa361eef5b7"},
+    {file = "glcontext-2.3.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ea3975a9d86a97b49f9524713c8e3f0df92044715cfbe5a24102e10762673b23"},
+    {file = "glcontext-2.3.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5f2e7fb61ea1f69c44db0799f8929ea66ad207619c18063ae60cfb26ad0f447f"},
+    {file = "glcontext-2.3.3-cp36-cp36m-win32.whl", hash = "sha256:bf8c3fa5f3a8962c9bcc03a869a0bb178bd1681619225b9f0a070a65ff3f766d"},
+    {file = "glcontext-2.3.3-cp36-cp36m-win_amd64.whl", hash = "sha256:e0b637f2ac1c2dd1e0dbfcbad6d7be2dae75290f9af8f82aa67aa55b977766e1"},
+    {file = "glcontext-2.3.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2002d29dee90e9ba800c8699e13e1ff8b0fa1292a7c5bb0a98ef50b5f6cd3f14"},
+    {file = "glcontext-2.3.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:941be8972ad64e70080ad4702c037c64c09d1378ddd9b1b4576b957bc2d7f1c2"},
+    {file = "glcontext-2.3.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0eb69c4add7f724017169bcefc2a8ef8ce053183e9384cc4770162e934090592"},
+    {file = "glcontext-2.3.3-cp37-cp37m-win32.whl", hash = "sha256:f63aed2116907225f7392921df790a391fd1a843cd1af0756dcd533e9d3ecf2b"},
+    {file = "glcontext-2.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:2fa9b939c15f5f7e63110a1021e8d20341c03921b8d3aebbb4bb191f11414d86"},
+    {file = "glcontext-2.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:44f95953bbd6a26caa9489b4f838b106470ede432c5ef837cd3e0d3657ca2a06"},
+    {file = "glcontext-2.3.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:843d3361bf46aec487f268bb7f680700166640995a82424fa86e53f428dc43ae"},
+    {file = "glcontext-2.3.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:be3e25a8595976699b6d30a2619ca4faf7bd5e60ff38dcd4445fa38a8f3b2cf9"},
+    {file = "glcontext-2.3.3-cp38-cp38-win32.whl", hash = "sha256:7abbd227bf9e4e62ec196360fa0f440143a66b7aae3d3deb7960b87aac654043"},
+    {file = "glcontext-2.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:b91010d033789d1f876789e4aa4e6498e87cd284b4d0cb7a4aa1b7e620caaf57"},
+    {file = "glcontext-2.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0a851f569f165a13f8fedf60dd4f2831f7c2ffbb9bc9f867d6e0e3fdd1846c8d"},
+    {file = "glcontext-2.3.3-cp39-cp39-win32.whl", hash = "sha256:f36935ba84e8c52ed22bb9f683875bdf1690abd318ae704f40511f1afca5f71a"},
+    {file = "glcontext-2.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:69e3a04c677e4925c0b6daf5efc5469a86d0982b05bb1d0ca29bce57f4aaf7d1"},
+    {file = "glcontext-2.3.3.tar.gz", hash = "sha256:f86a6c4ad99f941623911f964da74c443dc3f833fac7eb03cd485fae82acb80c"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1932,8 +1934,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.7.0-py3-none-any.whl", hash = "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"},
-    {file = "importlib_metadata-3.7.0.tar.gz", hash = "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa"},
+    {file = "importlib_metadata-3.7.3-py3-none-any.whl", hash = "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"},
+    {file = "importlib_metadata-3.7.3.tar.gz", hash = "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1948,8 +1950,8 @@ ipympl = [
     {file = "ipympl-0.6.3.tar.gz", hash = "sha256:bf2a33863ec9025d6d767f09b9f36dd8f7fe80d1f8f5ba08fca9f4e460ee64f8"},
 ]
 ipython = [
-    {file = "ipython-7.20.0-py3-none-any.whl", hash = "sha256:1918dea4bfdc5d1a830fcfce9a710d1d809cbed123e85eab0539259cb0f56640"},
-    {file = "ipython-7.20.0.tar.gz", hash = "sha256:1923af00820a8cf58e91d56b89efc59780a6e81363b94464a0f17c039dffff9e"},
+    {file = "ipython-7.21.0-py3-none-any.whl", hash = "sha256:34207ffb2f653bced2bc8e3756c1db86e7d93e44ed049daae9814fed66d408ec"},
+    {file = "ipython-7.21.0.tar.gz", hash = "sha256:04323f72d5b85b606330b6d7e2dc8d2683ad46c3905e955aa96ecc7a99388e70"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
@@ -1960,8 +1962,8 @@ ipywidgets = [
     {file = "ipywidgets-7.6.3.tar.gz", hash = "sha256:9f1a43e620530f9e570e4a493677d25f08310118d315b00e25a18f12913c41f0"},
 ]
 isort = [
-    {file = "isort-5.7.0-py3-none-any.whl", hash = "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"},
-    {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
+    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
+    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
 ]
 jedi = [
     {file = "jedi-0.18.0-py2.py3-none-any.whl", hash = "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93"},
@@ -1989,12 +1991,12 @@ jupyter = [
     {file = "jupyter-1.0.0.zip", hash = "sha256:3e1f86076bbb7c8c207829390305a2b1fe836d471ed54be66a3b8c41e7f46cc7"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-6.1.11-py3-none-any.whl", hash = "sha256:5eaaa41df449167ebba5e1cf6ca9b31f7fd4f71625069836e2e4fee07fe3cb13"},
-    {file = "jupyter_client-6.1.11.tar.gz", hash = "sha256:649ca3aca1e28f27d73ef15868a7c7f10d6e70f761514582accec3ca6bb13085"},
+    {file = "jupyter_client-6.1.12-py3-none-any.whl", hash = "sha256:e053a2c44b6fa597feebe2b3ecb5eea3e03d1d91cc94351a52931ee1426aecfc"},
+    {file = "jupyter_client-6.1.12.tar.gz", hash = "sha256:c4bca1d0846186ca8be97f4d2fa6d2bae889cce4892a167ffa1ba6bd1f73e782"},
 ]
 jupyter-console = [
-    {file = "jupyter_console-6.2.0-py3-none-any.whl", hash = "sha256:1d80c06b2d85bfb10bd5cc731b3db18e9023bc81ab00491d3ac31f206490aee3"},
-    {file = "jupyter_console-6.2.0.tar.gz", hash = "sha256:7f6194f4f4692d292da3f501c7f343ccd5e36c6a1becf7b7515e23e66d6bf1e9"},
+    {file = "jupyter_console-6.3.0-py3-none-any.whl", hash = "sha256:092283ba2c9b5ceb53f32d95891ecc59ed4bfeb69e36fe017db176213daa5b0e"},
+    {file = "jupyter_console-6.3.0.tar.gz", hash = "sha256:947f66bbdeee2221b4fb3a6b78225d337b8f10832f14cecf7932183635abe1d9"},
 ]
 jupyter-contrib-core = [
     {file = "jupyter_contrib_core-0.3.3-py2.py3-none-any.whl", hash = "sha256:1ec81e275a8f5858d56b0c4c6cd85335aa8e915001b8657fe51c620c3cdde50f"},
@@ -2016,12 +2018,12 @@ jupyter-server = [
     {file = "jupyter_server-1.4.1.tar.gz", hash = "sha256:b0126f237f679533eec46244cfc66d61e3a1f8ec0fad2d47352fa19d3e754e47"},
 ]
 jupyterlab = [
-    {file = "jupyterlab-3.0.9-py3-none-any.whl", hash = "sha256:03dc942696eeb6ecebe3482dec1973a8287f1a3973aca04fb64f13497029280b"},
-    {file = "jupyterlab-3.0.9.tar.gz", hash = "sha256:70aa808a1adc06e35701500a0b1cd2f472ad55b8d890153cb8bdfbd30b279646"},
+    {file = "jupyterlab-3.0.12-py3-none-any.whl", hash = "sha256:dbbbf6329c18422e7e22e95494933e7ea28b0fad09965cd60431b1b857f80ca2"},
+    {file = "jupyterlab-3.0.12.tar.gz", hash = "sha256:929c60d7fb4aa704084c02d8ededc209b8b378e0b3adab46158b7fa6acc24230"},
 ]
 jupyterlab-code-formatter = [
-    {file = "jupyterlab_code_formatter-1.4.4-py3-none-any.whl", hash = "sha256:57dd3d9dd669e21a35032e81207451ae7f7648353a47db6be75bfccebc3c0502"},
-    {file = "jupyterlab_code_formatter-1.4.4.tar.gz", hash = "sha256:f97081098953c4ead2a45af94ab6d42146ccf951a4b8cec6cd26f25a7238b8e5"},
+    {file = "jupyterlab_code_formatter-1.4.5-py3-none-any.whl", hash = "sha256:d43556de4854d5887b640c2dbb9951b1ef401f676240b03daef83b1a1bdaed92"},
+    {file = "jupyterlab_code_formatter-1.4.5.tar.gz", hash = "sha256:156b0328e4a8a2630a1fefd2baf6e8c898cbbfc32524c9151039ccf461ec6f8d"},
 ]
 jupyterlab-server = [
     {file = "jupyterlab_server-2.3.0-py3-none-any.whl", hash = "sha256:653cb811739e59f2f6998f659b4635a90c110a128e0245ce27dc3fe02c46543a"},
@@ -2171,28 +2173,28 @@ multiprocess = [
     {file = "multiprocess-0.70.11.1.zip", hash = "sha256:9d5e417f3ebce4d027a3c900995840f167f316d9f73c0a7a1fbb4ac0116298d0"},
 ]
 mypy = [
-    {file = "mypy-0.800-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:e1c84c65ff6d69fb42958ece5b1255394714e0aac4df5ffe151bc4fe19c7600a"},
-    {file = "mypy-0.800-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:947126195bfe4709c360e89b40114c6746ae248f04d379dca6f6ab677aa07641"},
-    {file = "mypy-0.800-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:b95068a3ce3b50332c40e31a955653be245666a4bc7819d3c8898aa9fb9ea496"},
-    {file = "mypy-0.800-cp35-cp35m-win_amd64.whl", hash = "sha256:ca7ad5aed210841f1e77f5f2f7d725b62c78fa77519312042c719ed2ab937876"},
-    {file = "mypy-0.800-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e32b7b282c4ed4e378bba8b8dfa08e1cfa6f6574067ef22f86bee5b1039de0c9"},
-    {file = "mypy-0.800-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e497a544391f733eca922fdcb326d19e894789cd4ff61d48b4b195776476c5cf"},
-    {file = "mypy-0.800-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:5615785d3e2f4f03ab7697983d82c4b98af5c321614f51b8f1034eb9ebe48363"},
-    {file = "mypy-0.800-cp36-cp36m-win_amd64.whl", hash = "sha256:2b216eacca0ec0ee124af9429bfd858d5619a0725ee5f88057e6e076f9eb1a7b"},
-    {file = "mypy-0.800-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e3b8432f8df19e3c11235c4563a7250666dc9aa7cdda58d21b4177b20256ca9f"},
-    {file = "mypy-0.800-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d16c54b0dffb861dc6318a8730952265876d90c5101085a4bc56913e8521ba19"},
-    {file = "mypy-0.800-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0d2fc8beb99cd88f2d7e20d69131353053fbecea17904ee6f0348759302c52fa"},
-    {file = "mypy-0.800-cp37-cp37m-win_amd64.whl", hash = "sha256:aa9d4901f3ee1a986a3a79fe079ffbf7f999478c281376f48faa31daaa814e86"},
-    {file = "mypy-0.800-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:319ee5c248a7c3f94477f92a729b7ab06bf8a6d04447ef3aa8c9ba2aa47c6dcf"},
-    {file = "mypy-0.800-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:74f5aa50d0866bc6fb8e213441c41e466c86678c800700b87b012ed11c0a13e0"},
-    {file = "mypy-0.800-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a301da58d566aca05f8f449403c710c50a9860782148332322decf73a603280b"},
-    {file = "mypy-0.800-cp38-cp38-win_amd64.whl", hash = "sha256:b9150db14a48a8fa114189bfe49baccdff89da8c6639c2717750c7ae62316738"},
-    {file = "mypy-0.800-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f5fdf935a46aa20aa937f2478480ebf4be9186e98e49cc3843af9a5795a49a25"},
-    {file = "mypy-0.800-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6f8425fecd2ba6007e526209bb985ce7f49ed0d2ac1cc1a44f243380a06a84fb"},
-    {file = "mypy-0.800-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:5ff616787122774f510caeb7b980542a7cc2222be3f00837a304ea85cd56e488"},
-    {file = "mypy-0.800-cp39-cp39-win_amd64.whl", hash = "sha256:90b6f46dc2181d74f80617deca611925d7e63007cf416397358aa42efb593e07"},
-    {file = "mypy-0.800-py3-none-any.whl", hash = "sha256:3e0c159a7853e3521e3f582adb1f3eac66d0b0639d434278e2867af3a8c62653"},
-    {file = "mypy-0.800.tar.gz", hash = "sha256:e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a"},
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -2211,8 +2213,8 @@ nbformat = [
     {file = "nbformat-5.1.2.tar.gz", hash = "sha256:1d223e64a18bfa7cdf2db2e9ba8a818312fc2a0701d2e910b58df66809385a56"},
 ]
 notebook = [
-    {file = "notebook-6.2.0-py3-none-any.whl", hash = "sha256:25ad93c982b623441b491e693ef400598d1a46cdf11b8c9c0b3be6c61ebbb6cd"},
-    {file = "notebook-6.2.0.tar.gz", hash = "sha256:0464b28e18e7a06cec37e6177546c2322739be07962dd13bf712bcb88361f013"},
+    {file = "notebook-6.3.0-py3-none-any.whl", hash = "sha256:cb271af1e8134e3d6fc6d458bdc79c40cbfc84c1eb036a493f216d58f0880e92"},
+    {file = "notebook-6.3.0.tar.gz", hash = "sha256:cbc9398d6c81473e9cdb891d2cae9c0d3718fca289dda6d26df5cb660fcadc7d"},
 ]
 numpy = [
     {file = "numpy-1.20.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ae61f02b84a0211abb56462a3b6cd1e7ec39d466d3160eb4e1da8bf6717cdbeb"},
@@ -2264,34 +2266,39 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 pillow = [
-    {file = "Pillow-8.1.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:d355502dce85ade85a2511b40b4c61a128902f246504f7de29bbeec1ae27933a"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:93a473b53cc6e0b3ce6bf51b1b95b7b1e7e6084be3a07e40f79b42e83503fbf2"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2353834b2c49b95e1313fb34edf18fca4d57446675d05298bb694bca4b194174"},
-    {file = "Pillow-8.1.0-cp36-cp36m-win32.whl", hash = "sha256:dd9eef866c70d2cbbea1ae58134eaffda0d4bfea403025f4db6859724b18ab3d"},
-    {file = "Pillow-8.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b09e10ec453de97f9a23a5aa5e30b334195e8d2ddd1ce76cc32e52ba63c8b31d"},
-    {file = "Pillow-8.1.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:b02a0b9f332086657852b1f7cb380f6a42403a6d9c42a4c34a561aa4530d5234"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ca20739e303254287138234485579b28cb0d524401f83d5129b5ff9d606cb0a8"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:604815c55fd92e735f9738f65dabf4edc3e79f88541c221d292faec1904a4b17"},
-    {file = "Pillow-8.1.0-cp37-cp37m-win32.whl", hash = "sha256:47c0d93ee9c8b181f353dbead6530b26980fe4f5485aa18be8f1fd3c3cbc685e"},
-    {file = "Pillow-8.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:96d4dc103d1a0fa6d47c6c55a47de5f5dafd5ef0114fa10c85a1fd8e0216284b"},
-    {file = "Pillow-8.1.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:7916cbc94f1c6b1301ac04510d0881b9e9feb20ae34094d3615a8a7c3db0dcc0"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3de6b2ee4f78c6b3d89d184ade5d8fa68af0848f9b6b6da2b9ab7943ec46971a"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cdbbe7dff4a677fb555a54f9bc0450f2a21a93c5ba2b44e09e54fcb72d2bd13d"},
-    {file = "Pillow-8.1.0-cp38-cp38-win32.whl", hash = "sha256:cb192176b477d49b0a327b2a5a4979552b7a58cd42037034316b8018ac3ebb59"},
-    {file = "Pillow-8.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6c5275bd82711cd3dcd0af8ce0bb99113ae8911fc2952805f1d012de7d600a4c"},
-    {file = "Pillow-8.1.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:165c88bc9d8dba670110c689e3cc5c71dbe4bfb984ffa7cbebf1fac9554071d6"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:5e2fe3bb2363b862671eba632537cd3a823847db4d98be95690b7e382f3d6378"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7612520e5e1a371d77e1d1ca3a3ee6227eef00d0a9cddb4ef7ecb0b7396eddf7"},
-    {file = "Pillow-8.1.0-cp39-cp39-win32.whl", hash = "sha256:dc577f4cfdda354db3ae37a572428a90ffdbe4e51eda7849bf442fb803f09c9b"},
-    {file = "Pillow-8.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:22d070ca2e60c99929ef274cfced04294d2368193e935c5d6febfd8b601bf865"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:a3d3e086474ef12ef13d42e5f9b7bbf09d39cf6bd4940f982263d6954b13f6a9"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:731ca5aabe9085160cf68b2dbef95fc1991015bc0a3a6ea46a371ab88f3d0913"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:bba80df38cfc17f490ec651c73bb37cd896bc2400cfba27d078c2135223c1206"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c3d911614b008e8a576b8e5303e3db29224b455d3d66d1b2848ba6ca83f9ece9"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:39725acf2d2e9c17356e6835dccebe7a697db55f25a09207e38b835d5e1bc032"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:81c3fa9a75d9f1afafdb916d5995633f319db09bd773cb56b8e39f1e98d90820"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:b6f00ad5ebe846cc91763b1d0c6d30a8042e02b2316e27b05de04fa6ec831ec5"},
-    {file = "Pillow-8.1.0.tar.gz", hash = "sha256:887668e792b7edbfb1d3c9d8b5d8c859269a0f0eba4dda562adb95500f60dbba"},
+    {file = "Pillow-8.1.2-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0"},
+    {file = "Pillow-8.1.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"},
+    {file = "Pillow-8.1.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8"},
+    {file = "Pillow-8.1.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34"},
+    {file = "Pillow-8.1.2-cp36-cp36m-win32.whl", hash = "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71"},
+    {file = "Pillow-8.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341"},
+    {file = "Pillow-8.1.2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6"},
+    {file = "Pillow-8.1.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28"},
+    {file = "Pillow-8.1.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d"},
+    {file = "Pillow-8.1.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be"},
+    {file = "Pillow-8.1.2-cp37-cp37m-win32.whl", hash = "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55"},
+    {file = "Pillow-8.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03"},
+    {file = "Pillow-8.1.2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e"},
+    {file = "Pillow-8.1.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce"},
+    {file = "Pillow-8.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af"},
+    {file = "Pillow-8.1.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06"},
+    {file = "Pillow-8.1.2-cp38-cp38-win32.whl", hash = "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09"},
+    {file = "Pillow-8.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060"},
+    {file = "Pillow-8.1.2-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1"},
+    {file = "Pillow-8.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6"},
+    {file = "Pillow-8.1.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238"},
+    {file = "Pillow-8.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910"},
+    {file = "Pillow-8.1.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1"},
+    {file = "Pillow-8.1.2-cp39-cp39-win32.whl", hash = "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e"},
+    {file = "Pillow-8.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0"},
+    {file = "Pillow-8.1.2-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b"},
+    {file = "Pillow-8.1.2-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2"},
+    {file = "Pillow-8.1.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb"},
+    {file = "Pillow-8.1.2-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328"},
+    {file = "Pillow-8.1.2-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c"},
+    {file = "Pillow-8.1.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733"},
+    {file = "Pillow-8.1.2-pp37-pypy37_pp73-win32.whl", hash = "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a"},
+    {file = "Pillow-8.1.2.tar.gz", hash = "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -2310,8 +2317,8 @@ prometheus-client = [
     {file = "prometheus_client-0.9.0.tar.gz", hash = "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.16-py3-none-any.whl", hash = "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"},
-    {file = "prompt_toolkit-3.0.16.tar.gz", hash = "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974"},
+    {file = "prompt_toolkit-3.0.17-py3-none-any.whl", hash = "sha256:4cea7d09e46723885cb8bc54678175453e5071e9449821dce6f017b1d1fbfc1a"},
+    {file = "prompt_toolkit-3.0.17.tar.gz", hash = "sha256:9397a7162cf45449147ad6042fa37983a081b8a73363a5253dd4072666333137"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -2329,8 +2336,8 @@ pycparser = [
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pygments = [
-    {file = "Pygments-2.8.0-py3-none-any.whl", hash = "sha256:b21b072d0ccdf29297a82a2363359d99623597b8a265b8081760e4d0f7153c88"},
-    {file = "Pygments-2.8.0.tar.gz", hash = "sha256:37a13ba168a02ac54cc5891a42b1caec333e59b66addb7fa633ea8a6d73445c0"},
+    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
+    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -2451,8 +2458,8 @@ qasync = [
     {file = "qasync-0.13.0.tar.gz", hash = "sha256:07a194a9f17706eec908596b3a40b469d2cbf81c1b9d3395357a4c91044ba2f2"},
 ]
 qtconsole = [
-    {file = "qtconsole-5.0.2-py3-none-any.whl", hash = "sha256:0173486b9cd69e17df537fb4f1e0d62a88019f6661700a11fd7236fa89ed900b"},
-    {file = "qtconsole-5.0.2.tar.gz", hash = "sha256:404994edfe33c201d6bd0c4bd501b00c16125071573c938533224992bea0b30f"},
+    {file = "qtconsole-5.0.3-py3-none-any.whl", hash = "sha256:4a38053993ca2da058f76f8d75b3d8906efbf9183de516f92f222ac8e37d9614"},
+    {file = "qtconsole-5.0.3.tar.gz", hash = "sha256:c091a35607d2a2432e004c4a112d241ce908086570cf68594176dd52ccaa212d"},
 ]
 qtpy = [
     {file = "QtPy-1.9.0-py2.py3-none-any.whl", hash = "sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea"},
@@ -2463,47 +2470,47 @@ recommonmark = [
     {file = "recommonmark-0.7.1.tar.gz", hash = "sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67"},
 ]
 regex = [
-    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
-    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
-    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
-    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
-    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
-    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
-    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
-    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
-    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
-    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
-    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
-    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
-    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
+    {file = "regex-2021.3.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd"},
+    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e"},
+    {file = "regex-2021.3.17-cp36-cp36m-win32.whl", hash = "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3"},
+    {file = "regex-2021.3.17-cp36-cp36m-win_amd64.whl", hash = "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5"},
+    {file = "regex-2021.3.17-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce"},
+    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643"},
+    {file = "regex-2021.3.17-cp37-cp37m-win32.whl", hash = "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be"},
+    {file = "regex-2021.3.17-cp37-cp37m-win_amd64.whl", hash = "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb"},
+    {file = "regex-2021.3.17-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c"},
+    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d"},
+    {file = "regex-2021.3.17-cp38-cp38-win32.whl", hash = "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf"},
+    {file = "regex-2021.3.17-cp38-cp38-win_amd64.whl", hash = "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa"},
+    {file = "regex-2021.3.17-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106"},
+    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7"},
+    {file = "regex-2021.3.17-cp39-cp39-win32.whl", hash = "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd"},
+    {file = "regex-2021.3.17-cp39-cp39-win_amd64.whl", hash = "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38"},
+    {file = "regex-2021.3.17.tar.gz", hash = "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
@@ -2575,8 +2582,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sphinx = [
-    {file = "Sphinx-3.5.1-py3-none-any.whl", hash = "sha256:e90161222e4d80ce5fc811ace7c6787a226b4f5951545f7f42acf97277bfc35c"},
-    {file = "Sphinx-3.5.1.tar.gz", hash = "sha256:11d521e787d9372c289472513d807277caafb1684b33eb4f08f7574c405893a9"},
+    {file = "Sphinx-3.5.3-py3-none-any.whl", hash = "sha256:3f01732296465648da43dec8fb40dc451ba79eb3e2cc5c6d79005fd98197107d"},
+    {file = "Sphinx-3.5.3.tar.gz", hash = "sha256:ce9c228456131bab09a3d7d10ae58474de562a6f79abb3dc811ae401cf8c1abc"},
 ]
 sphinx-autodoc-typehints = [
     {file = "sphinx-autodoc-typehints-1.11.1.tar.gz", hash = "sha256:244ba6d3e2fdb854622f643c7763d6f95b6886eba24bec28e86edf205e4ddb20"},
@@ -2611,16 +2618,16 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
 ]
 svgelements = [
-    {file = "svgelements-1.4.7-py2.py3-none-any.whl", hash = "sha256:ddfb192533e7254f90eb292b56c12e2b449cda163ce5cc8ee8b90acc245d56c6"},
-    {file = "svgelements-1.4.7.tar.gz", hash = "sha256:b85cc67348e734d0347a94152504c25cf88348a849b60765e8533b976f700793"},
+    {file = "svgelements-1.4.9-py2.py3-none-any.whl", hash = "sha256:dc674f2085fbf63d73ef1b6997fffa0d81b6236652a97ecd32017bf58c24e929"},
+    {file = "svgelements-1.4.9.tar.gz", hash = "sha256:1fc26ee4c561cd0c52ef55e2299afdf95038d11187c46627801416be90b179b1"},
 ]
 svgwrite = [
     {file = "svgwrite-1.4.1-py3-none-any.whl", hash = "sha256:4b21652a1d9c543a6bf4f9f2a54146b214519b7540ca60cb99968ad09ef631d0"},
     {file = "svgwrite-1.4.1.zip", hash = "sha256:e220a4bf189e7e214a55e8a11421d152b5b6fb1dd660c86a8b6b61fe8cc2ac48"},
 ]
 terminado = [
-    {file = "terminado-0.9.2-py3-none-any.whl", hash = "sha256:23a053e06b22711269563c8bb96b36a036a86be8b5353e85e804f89b84aaa23f"},
-    {file = "terminado-0.9.2.tar.gz", hash = "sha256:89e6d94b19e4bc9dce0ffd908dfaf55cc78a9bf735934e915a4a96f65ac9704c"},
+    {file = "terminado-0.9.3-py3-none-any.whl", hash = "sha256:430e876ec9d4d93a4fd8a49e82dcfae0c25f846540d0c5ca774b397533e237e8"},
+    {file = "terminado-0.9.3.tar.gz", hash = "sha256:261c0b7825fecf629666e1820b484a5380f7e54d6b8bd889fa482e99dcf9bde4"},
 ]
 testpath = [
     {file = "testpath-0.4.4-py2.py3-none-any.whl", hash = "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"},
@@ -2723,8 +2730,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
-    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 vpype = []
 watchgod = [
@@ -2744,6 +2751,6 @@ widgetsnbextension = [
     {file = "widgetsnbextension-3.5.1.tar.gz", hash = "sha256:079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7"},
 ]
 zipp = [
-    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
-    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ recommonmark = { version = ">=0.6,<0.8", optional = true }
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"
 pytest-benchmark = "^3.2.3"
-mypy = "^0.800"
+mypy = ">=0.800"
 jupyter = "^1.0.0"
 nbconvert = "5.6.1"
 nbformat = "^5.0.8"

--- a/vsketch/__init__.py
+++ b/vsketch/__init__.py
@@ -1,9 +1,10 @@
 """This module implements the vsketch API."""
 
-from .param import Param, ParamType
+from .sketch_class import Param, ParamType, SketchClass
+from .utils import working_directory
 from .vsketch import Vsketch
 
-__all__ = ["Vsketch", "Param", "ParamType"]
+__all__ = ["Vsketch", "Param", "ParamType", "SketchClass", "working_directory"]
 
 
 def _init():

--- a/vsketch/sketch_class.py
+++ b/vsketch/sketch_class.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import random
-from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import vpype as vp
@@ -13,6 +13,11 @@ ParamType = Union[int, float, bool, str]
 
 
 class SketchClass:
+    """Base class for sketch managed with the ``vsk`` CLI tool.
+
+    Subclass must override :meth:`draw` and :meth:`finalize`.
+    """
+
     def __init__(self):
         self._vsk = Vsketch()
         self._finalized = False
@@ -20,6 +25,7 @@ class SketchClass:
 
     @property
     def vsk(self) -> Vsketch:
+        """:class:`Vsketch` instance"""
         return self._vsk
 
     def execute_draw(self) -> None:
@@ -80,10 +86,14 @@ class SketchClass:
         return sketch
 
     @classmethod
-    def display(cls):
+    def display(cls, *args: Any, **kwargs: Any) -> None:
+        """Execute the sketch class and display the results using :meth:`Vsketch.display`.
+
+        All parameters are forwarded to :meth:`Vsketch.display`.
+        """
         sketch = cls.execute()
         if sketch is not None:
-            sketch.vsk.display()
+            sketch.vsk.display(*args, **kwargs)
 
     def draw(self, vsk: Vsketch) -> None:
         """Draws the sketch.
@@ -115,16 +125,12 @@ class SketchClass:
                 cls.__dict__[name].set_value_with_validation(value)
 
     @property
-    def params(self) -> Iterable["Param"]:
-        return self._params.values()
-
-    @property
     def param_set(self) -> Dict[str, Any]:
         return {name: param.value for name, param in self._params.items()}
 
 
 class Param:
-    """This class encapsulate a sketch parameter.
+    """This class encapsulate a :class:`SketchClass` parameter.
 
     A sketch parameter can be interacted with in the ``vsk`` viewer.
     """

--- a/vsketch/utils.py
+++ b/vsketch/utils.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING, Tuple
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator, Tuple
 
 import numpy as np
 
@@ -73,3 +76,13 @@ def compute_ellipse_mode(
         return c_x, c_y, width / 2, height / 2
     else:
         raise ValueError("mode must be one of 'corner', 'corners', 'center', 'radius'")
+
+
+@contextmanager
+def working_directory(path: pathlib.Path) -> Iterator:
+    prev_cwd = os.getcwd()
+    os.chdir(str(path))
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -37,10 +37,9 @@ T = TypeVar("T")
 
 # noinspection PyPep8Naming
 class Vsketch:
-    """This class represent a sketch.
+    """This class implement the core *vsketch* API.
 
-    Sketches should be implemented as :class:`Vsketch` subclasses and override the
-    :meth:`draw` and :meth:`finalize` methods.
+    All drawing are created through an instance of :class:`Vsketch`.
     """
 
     def __init__(self):

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -26,7 +26,6 @@ from shapely.geometry import Polygon
 from .curves import quadratic_bezier_path, quadratic_bezier_point, quadratic_bezier_tangent
 from .display import display
 from .fill import generate_fill
-from .param import Param
 from .style import stylize_path
 from .utils import MatrixPopper, ResetMatrixContextManager, complex_to_2d, compute_ellipse_mode
 
@@ -62,24 +61,6 @@ class Vsketch:
         self._random.seed(random.randint(0, 2 ** 31))
         self._noise = Noise()
         self.resetMatrix()
-
-        # extract params
-        self._params = self.get_params()
-
-    @classmethod
-    def get_params(cls) -> Dict[str, Param]:
-        res = {}
-        for name in cls.__dict__:
-            param = getattr(cls, name)
-            if isinstance(param, Param):
-                res[name] = param
-        return res
-
-    @classmethod
-    def set_param_set(cls, param_set: Dict[str, Any]) -> None:
-        for name, value in param_set.items():
-            if name in cls.__dict__ and isinstance(cls.__dict__[name], Param):
-                cls.__dict__[name].set_value_with_validation(value)
 
     @property
     def document(self):
@@ -1645,36 +1626,6 @@ class Vsketch:
             seed: the seed
         """
         self._noise.seed(seed)
-
-    #####################
-    # SKETCH MANAGEMENT #
-    #####################
-
-    # Pure virtual functions
-
-    def draw(self) -> None:
-        """Draws the sketch.
-
-        This function must be implemented by subclasses.
-        """
-        raise NotImplementedError()
-
-    def finalize(self) -> None:
-        """Finalize the sketch before export.
-
-        This function must be implemented by subclasses.
-        """
-        raise NotImplementedError()
-
-    # Param
-
-    @property
-    def params(self) -> Iterable[Param]:
-        return self._params.values()
-
-    @property
-    def param_set(self) -> Dict[str, Any]:
-        return {name: param.value for name, param in self._params.items()}
 
     #######################
     # STATELESS UTILITIES #

--- a/vsketch_cli/cli.py
+++ b/vsketch_cli/cli.py
@@ -13,13 +13,11 @@ import vsketch
 from .gui import show
 from .utils import (
     canonical_name,
-    execute_sketch,
     get_config_path,
     load_config,
     load_sketch_class,
     print_error,
     print_info,
-    working_directory,
 )
 
 cli = typer.Typer()
@@ -133,7 +131,7 @@ def init(
 
     dir_path = pathlib.Path(target)
 
-    with working_directory(dir_path.parent):
+    with vsketch.working_directory(dir_path.parent):
         cookiecutter(
             template,
             no_input=True,
@@ -323,13 +321,13 @@ def save(
 
         output_file = output_path / output_name
 
-        vsk = execute_sketch(sketch_class, finalize=True, seed=seed)
+        sketch = sketch_class.execute(finalize=True, seed=seed)
 
-        if vsk is None:
+        if sketch is None:
             print_error("Could not execute script: ", str(path))
             raise typer.Exit(code=1)
 
-        doc = vsk.document
+        doc = sketch.vsk.document
         with open(output_file, "w") as fp:
             print_info("Exporting SVG: ", str(output_file))
             vp.write_svg(

--- a/vsketch_cli/threads.py
+++ b/vsketch_cli/threads.py
@@ -6,15 +6,13 @@ from PySide2.QtCore import QThread, Signal
 
 import vsketch
 
-from .utils import execute_sketch
-
 
 class SketchRunnerThread(QThread):
-    completed = Signal(vsketch.Vsketch)
+    completed = Signal(vsketch.SketchClass)
 
     def __init__(
         self,
-        sketch_class: Type[vsketch.Vsketch],
+        sketch_class: Type[vsketch.SketchClass],
         seed: Optional[int],
         *args: Any,
         **kwargs: Any,
@@ -24,10 +22,10 @@ class SketchRunnerThread(QThread):
         self._seed = seed
 
     def run(self) -> None:
-        vsk = execute_sketch(self._sketch_class, seed=self._seed, finalize=False)
+        sketch = self._sketch_class.execute(seed=self._seed, finalize=False)
         if not self.isInterruptionRequested():
             # noinspection PyUnresolvedReferences
-            self.completed.emit(vsk)  # type: ignore
+            self.completed.emit(sketch)  # type: ignore
 
 
 class DocumentSaverThread(QThread):


### PR DESCRIPTION
#### Description

This PR introduces a new base class (`vsketch.SketchClass`) that must be sub-classed by user sketches (instead of `vsketch.Vsketch`). This is a major breaking change that will require modification to virtually every existing sketch.

New sketch template:

```python
import vsketch

class ExampleSketch(vsketch.SketchClass):
    rect_size = vsketch.Param(5)

    def draw(self, vsk: vsketch.Vsketch) -> None:
        vsk.size("a5", landscape=True)
        vsk.scale("cm")

        vsk.rect(0, 0, self.rect_size, self.rect_size)
        # etc.

    def finalize(self, vsk: vsketch.Vsketch) -> None:
        vsk.vpype("linemerge linesimplify reloop linesort")

if __name__ == "__main__":
    ExampleSketch()
```

There are two main reasons for this change:

1. Remove the namespace collision between `vsketch.Param` and `vksetch.Vsketch` API. For example, everyone wants a `scale` parameter for his sketch but with the sketch class inheriting from `vsketch.Vsketch`, naming a parameter `scale` would overwrite the `vsketch.Vsketch.scale()` method.
2. Remove the inconsistency between the "standalone" and the "sketch" use of `vsketch` API. Now the `vsk.XXX()` syntax is used in both use cases. 


#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [x] examples added/updated
- [x] code formatting ok (`black` and `isort`)
- [x] test all CLI/UI features
