### PR TITLE
Catch, Show, and Continue on Errors in Sketch Thread

### DIFF
--- a/vsketch_cli/threads.py
+++ b/vsketch_cli/threads.py
@@ -1,4 +1,5 @@
 import pathlib
+from traceback import format_exc
 from typing import Any, Optional, Type
 
 import vpype as vp
@@ -22,7 +23,11 @@ class SketchRunnerThread(QThread):
         self._seed = seed
 
     def run(self) -> None:
-        sketch = self._sketch_class.execute(seed=self._seed, finalize=False)
+        sketch = None
+        try:
+            sketch = self._sketch_class.execute(seed=self._seed, finalize=False)
+        except Exception as err:
+            print(f"Unexpected error when running sketch: {err}\n{format_exc()}")
         if not self.isInterruptionRequested():
             # noinspection PyUnresolvedReferences
             self.completed.emit(sketch)  # type: ignore


### PR DESCRIPTION
#### Description
I am running vsketch on Linux with Python 3.9 in a venv. I have an annoying issue where if there are any Python errors in the sketch Python file, vsketch simply freezes. It says "Loading..." in the window and prints the error to the console, but the window cannot be closed except by killing it and it no longer watches for changes.

This appears to be from `self._sketch_class.execute()` erroring and so it just sits and waits for the `completed` event to be emitted, but it is never emitted because the parent function crashes.

I have added a try/catch here that mitigates the issue. The window no longer freezes and now says "ERROR (see console)" as it is supposed to. Saving the file again causes it to update. The error is still printed to the console.

Thanks!

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
