### PR TITLE
WIP - Fix negative float inputs

### DIFF
--- a/vsketch_cli/param_widget.py
+++ b/vsketch_cli/param_widget.py
@@ -77,7 +77,7 @@ class FloatParamWidget(QDoubleSpinBox):
         elif val == 0.0:
             decimals = 1
         else:
-            decimals = max(1, 1 - math.floor(math.log10(val)))
+            decimals = max(1, 1 - math.floor(math.log10(abs(val))))
         self.setDecimals(decimals)
         if param.step is not None:
             self.setSingleStep(param.step)


### PR DESCRIPTION
#### Description

When param.decimals is None, the input value is run
through math. log10, which fails for negative default values.
This just runs abs on the value before doing the log.

#### Checklist

- [X] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
