### PR TITLE
Exit vsk run when Qt window is closed

### DIFF
--- a/vsketch_cli/gui.py
+++ b/vsketch_cli/gui.py
@@ -1,23 +1,31 @@
 import asyncio
 import pathlib
+import sys
 
 from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QApplication
-from qasync import QEventLoop
+from qasync import QEventLoop, QApplication
+import qasync
+import functools
 
 from .sketch_viewer import SketchViewer
 
 
-def show(path: str, second_screen: bool = False) -> int:
+async def _show(path: str, second_screen: bool = False) -> int:
+    def close_future(future, loop):
+        loop.call_later(10, future.cancel)
+        future.cancel()
+
+    loop = asyncio.get_event_loop()
+    future = asyncio.Future()
+
     if not QApplication.instance():
         app = QApplication()
     else:
         app = QApplication.instance()
     app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
-    # setup asyncio loop
-    loop = QEventLoop(app)
-    asyncio.set_event_loop(loop)
+    if hasattr(app, "aboutToQuit"):
+        getattr(app, "aboutToQuit").connect(functools.partial(close_future, future, loop))
 
     # create widget
     widget = SketchViewer(pathlib.Path(path))
@@ -36,7 +44,15 @@ def show(path: str, second_screen: bool = False) -> int:
 
     # run
     widget.show()
+    await future
     return app.exec_()
+
+
+def show(path: str, second_screen: bool = False) -> int:
+    try:
+        qasync.run(_show(path, second_screen))
+    except asyncio.exceptions.CancelledError:
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/vsketch_cli/gui.py
+++ b/vsketch_cli/gui.py
@@ -16,7 +16,7 @@ async def _show(path: str, second_screen: bool = False) -> int:
         future.cancel()
 
     loop = asyncio.get_event_loop()
-    future = asyncio.Future()
+    future: asyncio.Future = asyncio.Future()
 
     if not QApplication.instance():
         app = QApplication()
@@ -50,7 +50,7 @@ async def _show(path: str, second_screen: bool = False) -> int:
 
 def show(path: str, second_screen: bool = False) -> int:
     try:
-        qasync.run(_show(path, second_screen))
+        return qasync.run(_show(path, second_screen))
     except asyncio.exceptions.CancelledError:
         sys.exit(0)
 

--- a/vsketch_cli/gui.py
+++ b/vsketch_cli/gui.py
@@ -1,11 +1,11 @@
 import asyncio
+import functools
 import pathlib
 import sys
 
-from PySide2.QtCore import Qt
-from qasync import QEventLoop, QApplication
 import qasync
-import functools
+from PySide2.QtCore import Qt
+from qasync import QApplication, QEventLoop
 
 from .sketch_viewer import SketchViewer
 

--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -14,9 +14,9 @@ from PySide2.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from qasync import asyncClose
 
 import vsketch
-from qasync import asyncClose
 
 from .config_widget import ConfigWidget
 from .param_widget import ParamsWidget

--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -14,7 +14,6 @@ from PySide2.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qasync import asyncClose
 
 import vsketch
 


### PR DESCRIPTION
#### Description

Attempt at fixing an issue where the `vsk run` command hangs/continues running after the Qt window is closed.

I don't fully understand the fix, as I don't have much experience with Qt or asyncio, but I adopted some lines from various python Qt examples, and added an stop event to the file watcher.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
