### PR TITLE
Fix `rectMode` `radius` typo in the documentation for 3 methods

### DIFF
--- a/vsketch/shape.py
+++ b/vsketch/shape.py
@@ -456,7 +456,7 @@ class Shape:
             tr: top-right corner radius (same as tl if not provided)
             br: bottom-right corner radius (same as tr if not provided)
             bl: bottom-left corner radius (same as br if not provided)
-            mode: "corner", "corners", "redius", or "center" (see :meth:`rectMode`)
+            mode: "corner", "corners", "radius", or "center" (see :meth:`rectMode`)
             op: one of 'union', 'difference', 'intersection', or 'symmetric_difference'
         """
         if len(radii) == 0:
@@ -533,7 +533,7 @@ class Shape:
             x: X coordinate of top-left corner
             y: Y coordinate of top-left corner
             extent: width and height of the square
-            mode: "corner", "redius", or "center" (see :meth:`rectMode`) — note that the
+            mode: "corner", "radius", or "center" (see :meth:`rectMode`) — note that the
                 "corners" mode is meaningless for this function, and is interpreted as the
                 "corner" mode
             op: one of 'union', 'difference', 'intersection', or 'symmetric_difference'

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -792,7 +792,7 @@ class Vsketch:
             tr: top-right corner radius (same as tl if not provided)
             br: bottom-right corner radius (same as tr if not provided)
             bl: bottom-left corner radius (same as br if not provided)
-            mode: "corner", "corners", "redius", or "center" (see :meth:`rectMode`)
+            mode: "corner", "corners", "radius", or "center" (see :meth:`rectMode`)
         """
         if len(radii) == 0:
             radii = (0, 0, 0, 0)


### PR DESCRIPTION
#### Description

3 methods that use `rectMode` strings had the `radius` mode misspelled as `redius`

#### Checklist

- [ ] feature/fix implemented
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
