### PR TITLE
use toPlainText() to retrieve value of text field

### DIFF
--- a/vsketch_cli/param_widget.py
+++ b/vsketch_cli/param_widget.py
@@ -112,7 +112,7 @@ class TextParamWidget(QTextEdit):
         self.textChanged.connect(self.update_param)  # type: ignore
 
     def update_param(self):
-        self._param.set_value_with_validation(self.text())  # type: ignore
+        self._param.set_value_with_validation(self.toPlainText())  # type: ignore
         # noinspection PyUnresolvedReferences
         self.value_changed.emit()
 


### PR DESCRIPTION
#### Description

Resolves #109 using @bcongdon's suggestion of `toPlainText()`. I couldn't find any tests that cover the viewer so I manually confirmed that both free text and `choices` type params live update and save/load correctly. Let me know if I'm just missing the tests.

#### Checklist

- [X] feature/fix implemented
- [X] `mypy` returns no error
- [X] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [X] code formatting ok (`black` and `isort`)
