### PR TITLE
add shortcuts to like and randomize

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -85,6 +85,13 @@ If configurations have been saved using ``vsk run``, they can be used for export
     $ vsk save --config my_config my_project
 
 
+Shortcuts
+---------
+
+* 's' to like the sketch
+* 'r' to generate a new seed
+
+
 Beyond the basics?
 ------------------
 

--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -6,10 +6,12 @@ from typing import Any, Dict, Optional, Type
 import vpype_viewer
 import watchfiles
 from PySide2.QtCore import QThread, Signal
+from PySide2.QtGui import QKeySequence
 from PySide2.QtWidgets import (
     QLabel,
     QPushButton,
     QScrollArea,
+    QShortcut,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
@@ -93,6 +95,12 @@ class SketchViewer(vpype_viewer.QtViewer):
         sp.setHorizontalPolicy(QSizePolicy.Minimum)
         scroller.setSizePolicy(sp)
         self.add_side_widget(scroller)
+
+        likeShortcut = QShortcut(QKeySequence("S"), self)
+        likeShortcut.activated.connect(self.on_like)
+
+        randomizeShortcut = QShortcut(QKeySequence("R"), self)
+        randomizeShortcut.activated.connect(self._sidebar.seed_widget.randomize_seed)
 
         self._trigger_fit_to_viewport = True
         self.reload_sketch_class()


### PR DESCRIPTION
#### Description

I've added a couple shortcuts to save and randomize a sketch. I assigned the "S" shortcut to ~save~ like a drawing and "R" to randomize the seed, but I'm open to other options.

Also, I'm not quite sure if I should update the doc in some way.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
