### PR TITLE
param_widget: fix TextParamWidget

### DIFF
--- a/vsketch_cli/param_widget.py
+++ b/vsketch_cli/param_widget.py
@@ -112,7 +112,7 @@ class TextParamWidget(QTextEdit):
         self.textChanged.connect(self.update_param)
 
     def update_param(self):
-        self._param.set_value_with_validation(self.text())
+        self._param.set_value_with_validation(self.toPlainText())
         # noinspection PyUnresolvedReferences
         self.value_changed.emit()
 


### PR DESCRIPTION
There's no text() method in QTextEdit, treat the text as plain text.

#### Description

If I try to change a text parameter via the vsketch cli I get the following error

```python
Traceback (most recent call last):                       
  File "/home/daniele/.local/pipx/venvs/vsketch/lib/python3.10/site-packages/vsketch_cli/param_widget.py", line 115, in update_param
    self._param.set_value_with_validation(self.text())
AttributeError: 'TextParamWidget' object has no attribute 'text'                                                                         
Traceback (most recent call last):                    
  File "/home/daniele/.local/pipx/venvs/vsketch/lib/python3.10/site-packages/vsketch_cli/param_widget.py", line 115, in update_param
    self._param.set_value_with_validation(self.text())
AttributeError: 'TextParamWidget' object has no attribute 'text'
```
The problem seems that `QTextEdit` has no `text()` method, but it has `toPlainText`, `toHTML` and similar. I used `toPlainText` because it seemed to safest choice.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
