### PR TITLE
Modify path before executing sketch scripts

### DIFF
--- a/vsketch_cli/utils.py
+++ b/vsketch_cli/utils.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import os
 import pathlib
+import sys
 import traceback
 from runpy import run_path
 from typing import Dict, Optional, Type
@@ -62,6 +63,8 @@ def load_sketch_class(path: pathlib.Path) -> Optional[Type[vsketch.SketchClass]]
     # noinspection PyBroadException
     try:
         with vsketch.working_directory(cwd_path):
+            if str(cwd_path) not in sys.path:
+                sys.path.insert(0, str(cwd_path))
             sketch_scripts = run_path(str(path))  # type: ignore
     except Exception:
         traceback.print_exc()


### PR DESCRIPTION
#### Description

Modifies the path before executing a sketch script

Fixes #177 

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
