### PR TITLE
Save sketch parameters in svg source tag on like

### DIFF
--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -151,7 +151,10 @@ class SketchViewer(vpype_viewer.QtViewer):
         self._sketch.ensure_finalized()
 
         # launch saving process in a thread
-        thread = DocumentSaverThread(path, self._sketch.vsk.document, self)
+        params = dict(__seed__=self._sketch.vsk.random_seed, **self._sketch.param_set)
+        thread = DocumentSaverThread(
+            path, self._sketch.vsk.document, self, source=f"Vsketch with params {params}"
+        )
         self._sidebar.setEnabled(False)
         self._sidebar.like_btn.setText("saving...")
         thread.completed.connect(self.on_like_completed)  # type: ignore

--- a/vsketch_cli/threads.py
+++ b/vsketch_cli/threads.py
@@ -41,15 +41,17 @@ class DocumentSaverThread(QThread):
         path: pathlib.Path,
         document: vp.Document,
         *args: Any,
+        source: str = "",
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self._path = path
         self._document = document
+        self._source = source
 
     def run(self) -> None:
         with open(self._path, "w") as fp:
-            vp.write_svg(fp, self._document)
+            vp.write_svg(fp, self._document, source_string=self._source)
         # noinspection PyUnresolvedReferences
         self.completed.emit()  # type: ignore
         self.deleteLater()


### PR DESCRIPTION
#### Description

Adds a feature to store the sketch parameters (and the seed! see #87) in the svg source tag when saving using the LIKE button. The format is designed to be the same what is found in config json files.

Sometimes I save things with a good set of parameters, but then I make a change to the sketch with a syntax error and loose my nice config.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
