### PR TITLE
typo in example command

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,7 +26,7 @@ Running the examples
 
 Installing *vsketch* with pipx does *not* install the examples and they must be downloaded separately. An archive from the latest version of the *vsketch* `repository <https://github.com/abey79/vsketch>`__ can be downloaded `here <https://github.com/abey79/vsketch/archive/refs/heads/master.zip>`__. After uncompressing the archive, you can readily execute the examples::
 
-  $ vsk run path/to/vsketch-master/examples/shotter
+  $ vsk run path/to/vsketch-master/examples/schotter
 
 
 Installing plug-ins


### PR DESCRIPTION
#### Description

...

#### Checklist

- [ ] feature/fix implemented
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
