### PR TITLE
drop invalid mode="matplotlib" arg in notebooks

### DIFF
--- a/examples/_notebooks/bezier_bugs.ipynb
+++ b/examples/_notebooks/bezier_bugs.ipynb
@@ -24772,7 +24772,7 @@
     "        y = row * 100.5\n",
     "        bug(x, y)\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\", fig_size=(12, 12))\n",
+    "vsk.display(fig_size=(12, 12))\n",
     "vsk.save(\"bezier_bugs.svg\", color_mode=\"none\")"
    ]
   }

--- a/examples/_notebooks/detail.ipynb
+++ b/examples/_notebooks/detail.ipynb
@@ -368,7 +368,7 @@
     "    vsk.scale(4)\n",
     "    vsk.circle(0, 0, 1)\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"detail.svg\")"
    ]
   }

--- a/examples/_notebooks/noise_bezier.ipynb
+++ b/examples/_notebooks/noise_bezier.ipynb
@@ -4658,7 +4658,7 @@
     "        vsk.noise(t, 7000) * 10 + v,\n",
     "    )\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")"
+    "vsk.display()"
    ]
   }
  ],

--- a/examples/_notebooks/polygons.ipynb
+++ b/examples/_notebooks/polygons.ipynb
@@ -396,7 +396,7 @@
     "    angles = np.linspace(0, 2 * np.pi, i + 4)\n",
     "    vsk.polygon((i + 1) * np.cos(angles + phase), (i + 1) * np.sin(angles + phase))\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"polygons.svg\")"
    ]
   }

--- a/examples/_notebooks/prime_circles.ipynb
+++ b/examples/_notebooks/prime_circles.ipynb
@@ -5310,7 +5310,7 @@
     "vsk.vpype(\"linemerge linesort\")\n",
     "\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"prime_circles.svg\")"
    ]
   }

--- a/examples/_notebooks/quick_draw.ipynb
+++ b/examples/_notebooks/quick_draw.ipynb
@@ -1958,7 +1958,7 @@
     "    if (i + 1) % grid_size == 0:\n",
     "        vsk.translate(-grid_size * vsk.width, vsk.height)\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\", fig_size=(12, 12))\n",
+    "vsk.display(fig_size=(12, 12))\n",
     "vsk.save(f\"quick_draw_{QUICKDRAW_SET_NAME}.svg\")"
    ]
   }

--- a/examples/_notebooks/random.ipynb
+++ b/examples/_notebooks/random.ipynb
@@ -35758,7 +35758,7 @@
     "    )\n",
     "    vsk.polygon(x_coords, y_coords)\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"random_lines.svg\")\n"
    ]
   },
@@ -56074,7 +56074,7 @@
     "\n",
     "    vsk.polygon(np.cumsum(xoffset), np.cumsum(yoffset))\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"random_flower.svg\")"
    ]
   }

--- a/examples/_notebooks/shapely.ipynb
+++ b/examples/_notebooks/shapely.ipynb
@@ -16999,7 +16999,7 @@
     "        )\n",
     "        vsk.geometry(translate(shape, i * 8, j * 8))\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"shapely.svg\")"
    ]
   }

--- a/examples/_notebooks/stroke_fill.ipynb
+++ b/examples/_notebooks/stroke_fill.ipynb
@@ -2011,7 +2011,7 @@
     "vsk.geometry(p)\n",
     "\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\", fig_size=(12, 8))\n",
+    "vsk.display(fig_size=(12, 8))\n",
     "vsk.save(\"stroke_fill.svg\")"
    ]
   }

--- a/examples/_notebooks/subsketch.ipynb
+++ b/examples/_notebooks/subsketch.ipynb
@@ -513,7 +513,7 @@
     "    vsk.translate(3, 0)\n",
     "\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"subsketch_basic.svg\")"
    ]
   },
@@ -6757,7 +6757,7 @@
     "    vsk.rotate(10, degrees=True)\n",
     "    vsk.sketch(vsk)\n",
     "    \n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"subsketch_recursive.svg\")"
    ]
   }

--- a/examples/_notebooks/transforms.ipynb
+++ b/examples/_notebooks/transforms.ipynb
@@ -194,7 +194,7 @@
     "\n",
     "    vsk.translate(2, 0)\n",
     "\n",
-    "vsk.display(mode=\"matplotlib\")\n",
+    "vsk.display()\n",
     "vsk.save(\"transforms.svg\")"
    ]
   }


### PR DESCRIPTION
#### Description

The examples in `examples/_notebooks` have `vsk.display(mode="matplotlib")` which is apparently an old / invalid argument (`matplotlib` seems to be the only supported mode now); this change removes them.

(I understand that running `vsketch` in notebooks is unsupported. Still I find it to be a really useful way to explore a new library, especially as a Python beginner.)

#### Checklist

- [ ] feature/fix implemented
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [x] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
