### PR TITLE
save params in svg as json

### DIFF
--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -151,10 +151,7 @@ class SketchViewer(vpype_viewer.QtViewer):
         self._sketch.ensure_finalized()
 
         # launch saving process in a thread
-        params = dict(__seed__=self._sketch.vsk.random_seed, **self._sketch.param_set)
-        thread = DocumentSaverThread(
-            path, self._sketch.vsk.document, self, source=f"Vsketch with params {params}"
-        )
+        thread = DocumentSaverThread(path, self._sketch, self)
         self._sidebar.setEnabled(False)
         self._sidebar.like_btn.setText("saving...")
         thread.completed.connect(self.on_like_completed)  # type: ignore

--- a/vsketch_cli/threads.py
+++ b/vsketch_cli/threads.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 from traceback import format_exc
 from typing import Any, Optional, Type
@@ -39,19 +40,20 @@ class DocumentSaverThread(QThread):
     def __init__(
         self,
         path: pathlib.Path,
-        document: vp.Document,
+        sketch: vsketch.SketchClass,
         *args: Any,
-        source: str = "",
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self._path = path
-        self._document = document
-        self._source = source
+        self._sketch = sketch
 
     def run(self) -> None:
+        document = self._sketch.vsk.document
+        params = self._sketch.param_set
+        params["__seed__"] = self._sketch.vsk.random_seed
         with open(self._path, "w") as fp:
-            vp.write_svg(fp, self._document, source_string=self._source)
+            vp.write_svg(fp, document, source_string=json.dumps(params))
         # noinspection PyUnresolvedReferences
         self.completed.emit()  # type: ignore
         self.deleteLater()


### PR DESCRIPTION
#### Description

This reworks #327 to store the parameters in json rather than a serialized python dict. This allows for safer parsing without needing to eval python. It also refactors the save thread to pass the entire sketch object in so the thread can handle all the parsing/generating logic locally.

The only potential downside is that the quote marks in json are entity encoded in the svg, so it's quite a bit less readable for humans.

Before:

```
$ grep dc:source before.svg
        <dc:source>Vsketch with params {'__seed__': 330354623, 'units': 'in', 'paper_size': '10.5x14.8cm', 'landscape': False, 'centered': True, 'margin': 0.09999999999999996, 'fill_pen': 'Gelly Roll Metallic', 'stroke_pen': 'Sharpie Fine Point', 'show_layout': False, 'show_sublayout': False, 'vpype_preview': True, 'rows': 5, 'columns': 3, 'cell_padding': 0.1, 'radius_percent': 0.08, 'jitter_percent': 1.0, 'line_shorten_max': 0.2, 'ball_count': 3}
```

After:

```
$ grep dc:source after.svg
        <dc:source>{&quot;units&quot;: &quot;in&quot;, &quot;paper_size&quot;: &quot;10.5x14.8cm&quot;, &quot;landscape&quot;: false, &quot;centered&quot;: true, &quot;margin&quot;: 0.2, &quot;fill_pen&quot;: &quot;Gelly Roll Metallic&quot;, &quot;stroke_pen&quot;: &quot;Sharpie Fine Point&quot;, &quot;show_layout&quot;: true, &quot;show_sublayout&quot;: true, &quot;vpype_preview&quot;: false, &quot;rows&quot;: 1, &quot;columns&quot;: 1, &quot;cell_padding&quot;: 0.1, &quot;radius_percent&quot;: 0.08, &quot;jitter_percent&quot;: 1.0, &quot;line_shorten_max&quot;: 0.2, &quot;ball_count&quot;: 3, &quot;__seed__&quot;: 0}</dc:source>
```

Personally I think this is a small price to pay for easier programmatic extraction but I'd like to hear what @tyehle thinks.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)