### PR TITLE
add test for path length

### DIFF
--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -1,10 +1,11 @@
 from typing import Tuple
 
+import numpy as np
 import pytest
 
 import vsketch
 
-from .utils import bounds_equal, line_count_equal
+from .utils import bounds_equal, length_equal, line_count_equal
 
 
 def test_circle_default(vsk: vsketch.Vsketch) -> None:
@@ -12,12 +13,14 @@ def test_circle_default(vsk: vsketch.Vsketch) -> None:
     vsk.detail(0.01)  # make sure we have a tight bound match
     vsk.circle(0, 0, 5)
     assert line_count_equal(vsk, 1)
+    assert length_equal(vsk, 5 * np.pi)
     assert bounds_equal(vsk, -2.5, -2.5, 2.5, 2.5)
 
 
 def test_circle_radius(vsk: vsketch.Vsketch) -> None:
     vsk.circle(0, 0, radius=5)
     assert line_count_equal(vsk, 1)
+    assert length_equal(vsk, 5 * 2 * np.pi)
     assert bounds_equal(vsk, -5, -5, 5, 5)
 
 
@@ -25,6 +28,7 @@ def test_circle_diameter(vsk: vsketch.Vsketch) -> None:
     vsk.detail(0.01)  # make sure we have a tight bound match
     vsk.circle(0, 0, diameter=5)
     assert line_count_equal(vsk, 1)
+    assert length_equal(vsk, 5 * np.pi)
     assert bounds_equal(vsk, -2.5, -2.5, 2.5, 2.5)
 
 

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1,7 +1,11 @@
-from .utils import bounds_equal, line_count_equal
+import numpy as np
+
+from .utils import bounds_equal, length_equal, line_count_equal, line_exists
 
 
 def test_line(vsk):
     vsk.line(5, 5, 10, 5)
     assert line_count_equal(vsk, 1)
+    assert line_exists(vsk, np.array([5 + 5j, 10 + 5j]))
+    assert length_equal(vsk, 5)
     assert bounds_equal(vsk, 5, 5, 10, 5)

--- a/tests/test_rect.py
+++ b/tests/test_rect.py
@@ -5,13 +5,14 @@ import pytest
 
 import vsketch
 
-from .utils import bounds_equal, line_count_equal, line_exists
+from .utils import bounds_equal, length_equal, line_count_equal, line_exists
 
 
 def test_rect_default_success(vsk: vsketch.Vsketch) -> None:
     vsk.rect(0, 0, 2, 4)
     assert line_count_equal(vsk, 1)
     assert line_exists(vsk, np.array([0, 2, 2 + 4j, 4j, 0], dtype=complex), strict=False)
+    assert length_equal(vsk, (2 + 4) * 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,13 @@ def bounds_equal(
     )
 
 
+def length_equal(vsk: vsketch.Vsketch, length: float) -> bool:
+    """Asserts that sketch length is approximately equal to those provided"""
+
+    length_ = vsk.document.length()
+    return bool(length is not None and np.isclose(length_, length, rtol=1e-03))
+
+
 def line_count_equal(vsk: vsketch.Vsketch, *args: Union[int, Tuple[int, int]]) -> bool:
     """Asserts that layers have the given number of path. Any number of path count can be
     passed as argument, either as single int (layer ID is then inferred or as (layer_ID, n)


### PR DESCRIPTION
#### Description

Add a utility function to the test suite to test if the length of path drawn is equal to the expected length: `length_equal`

This was written to help show odd behavior of `vsk.circle` when the radius was negative https://github.com/abey79/vsketch/issues/352

In this PR the function `length_equal` is added and then used in existing tests where the length is known.

length_equal is written in the style of existing testing utility functions such as bounds_equal and uses np.close with rtol=1e-3. This means the paths will be considered to be the same length if the difference is within 0.001. This made sense to also use for this case because the calculated length is based on drawing a perfect circle with a circumference of diameter * pi, which is not exactly what is being drawn and even if it was there would be some error inherent from comparing floats and we would want some tolerance.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [x] examples added/updated
- [x] code formatting ok (`black` and `isort`)
