### PR TITLE
Set 'use_svg_metadata' to True in call to vpype.write_svg

### DIFF
--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -1479,6 +1479,7 @@ class Vsketch:
                     color_mode=color_mode,
                     layer_label_format=layer_label,
                     source_string="Generated with vsketch",
+                    use_svg_metadata=True,
                 )
             elif format == "hpgl":
                 if device is None:


### PR DESCRIPTION
Allows manipulation of 'svg_' properties directly within vsketch.

#### Description

...

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
