### PR TITLE
Fix previous incomplete PR#380 regarding use_svg_metadata

### DIFF
--- a/vsketch_cli/cli.py
+++ b/vsketch_cli/cli.py
@@ -476,6 +476,7 @@ def save(
                 fp,
                 doc,
                 source_string=source_string,
+                use_svg_metadata=True,
             )
 
     all_output_iterator = itertools.product(

--- a/vsketch_cli/threads.py
+++ b/vsketch_cli/threads.py
@@ -52,7 +52,12 @@ class DocumentSaverThread(QThread):
 
     def run(self) -> None:
         with open(self._path, "w") as fp:
-            vp.write_svg(fp, self._document, source_string=self._source)
+            vp.write_svg(
+                fp,
+                self._document,
+                source_string=self._source,
+                use_svg_metadata=True,
+            )
         # noinspection PyUnresolvedReferences
         self.completed.emit()  # type: ignore
         self.deleteLater()


### PR DESCRIPTION
#### Description

Completes previous incomplete PR#380.  There were additional codepaths to vp.write_svg calls that I missed in the earlier PR.
...

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
