### PR TITLE
Updated Shape.geometry to accept MultiPoint objects.

### DIFF
--- a/vsketch/shape.py
+++ b/vsketch/shape.py
@@ -731,7 +731,7 @@ class Shape:
 
     def geometry(
         self,
-        shape: LineString | LinearRing | MultiPoint | MultiPolygon | MultiLineString | Point| Polygon,
+        shape: LineString | LinearRing | MultiPoint | MultiPolygon | MultiLineString | Point | Polygon,
         op: BooleanOperation = "union",
     ) -> None:
         """Add a Shapely geometry to the shape.

--- a/vsketch/shape.py
+++ b/vsketch/shape.py
@@ -731,12 +731,18 @@ class Shape:
 
     def geometry(
         self,
-        shape: LineString | LinearRing | MultiPoint | MultiPolygon | MultiLineString | Point | Polygon,
+        shape: LineString
+        | LinearRing
+        | MultiPoint
+        | MultiPolygon
+        | MultiLineString
+        | Point
+        | Polygon,
         op: BooleanOperation = "union",
     ) -> None:
         """Add a Shapely geometry to the shape.
 
-        This function should accept any of LineString, LinearRing, MultiPoint, 
+        This function should accept any of LineString, LinearRing, MultiPoint,
         MultiPolygon, MultiLineString, Point, or Polygon.
 
         This function support multiple boolean modes with the ``op`` argument: ``union``

--- a/vsketch/shape.py
+++ b/vsketch/shape.py
@@ -731,20 +731,20 @@ class Shape:
 
     def geometry(
         self,
-        shape: LineString | LinearRing | MultiPolygon | MultiPoint | MultiLineString | Polygon,
+        shape: LineString | LinearRing | MultiPoint | MultiPolygon | MultiLineString | Point| Polygon,
         op: BooleanOperation = "union",
     ) -> None:
         """Add a Shapely geometry to the shape.
 
-        This function should accept any of LineString, LinearRing, MultiPolygon,
-        MultiPoint, MultiLineString, or Polygon.
+        This function should accept any of LineString, LinearRing, MultiPoint, 
+        MultiPolygon, MultiLineString, Point, or Polygon.
 
         This function support multiple boolean modes with the ``op`` argument: ``union``
         (default, the geometry is added to the shape), ``difference`` (the geometry is cut off
         the shape), ``intersection`` (only the overlapping part of the geometry is kept in the
         shape), or ``symmetric_difference`` (only the none overlapping parts of the shape and
         geometry are kept).  The ``op`` argument is ignored if ``shape`` is a MultiPoint
-        object.
+        or Point object.
 
         .. seealso::
 
@@ -772,8 +772,12 @@ class Shape:
                     self.polygon(
                         p.exterior.coords, holes=[hole.coords for hole in p.interiors], op=op
                     )
-            elif shape.geom_type == "MultiPoint":
-                for p in shape.geoms:
+            elif shape.geom_type in ["Point", "MultiPoint"]:
+                if shape.geom_type == "Point":
+                    point_list = [shape]
+                else:
+                    point_list = shape.geoms
+                for p in point_list:
                     self.point(p.x, p.y)
             else:
                 raise ValueError("unsupported Shapely geometry")

--- a/vsketch/shape.py
+++ b/vsketch/shape.py
@@ -731,19 +731,20 @@ class Shape:
 
     def geometry(
         self,
-        shape: LineString | LinearRing | MultiPolygon | MultiLineString | Polygon,
+        shape: LineString | LinearRing | MultiPolygon | MultiPoint | MultiLineString | Polygon,
         op: BooleanOperation = "union",
     ) -> None:
         """Add a Shapely geometry to the shape.
 
         This function should accept any of LineString, LinearRing, MultiPolygon,
-        MultiLineString, or Polygon.
+        MultiPoint, MultiLineString, or Polygon.
 
-        This function support multiple boolean mode with the ``op`` argument: ``union``
+        This function support multiple boolean modes with the ``op`` argument: ``union``
         (default, the geometry is added to the shape), ``difference`` (the geometry is cut off
         the shape), ``intersection`` (only the overlapping part of the geometry is kept in the
         shape), or ``symmetric_difference`` (only the none overlapping parts of the shape and
-        geometry are kept).
+        geometry are kept).  The ``op`` argument is ignored if ``shape`` is a MultiPoint
+        object.
 
         .. seealso::
 
@@ -771,6 +772,9 @@ class Shape:
                     self.polygon(
                         p.exterior.coords, holes=[hole.coords for hole in p.interiors], op=op
                     )
+            elif shape.geom_type == "MultiPoint":
+                for p in shape.geoms:
+                    self.point(p.x, p.y)
             else:
                 raise ValueError("unsupported Shapely geometry")
         except AttributeError:


### PR DESCRIPTION
#### Description

Adds the ability for Shape.geometry() to accept a shapely MultiPoint object.  Per discussion on discord.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
