### PR TITLE
Add CLI option to choose output directory for vsk run

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -60,6 +60,9 @@ If the ``--editor`` option is passed, it will be used to open the sketch script 
 Most popular IDE and editors have such a command (e.g. ``charm`` for PyCharm, ``code`` for VSCode, ``mate`` for
 TextMate, etc.). Again, setting the ``VSK_EDITOR`` environment variable enables this feature permanently.
 
+The "like" button will save an SVG the current sketch to a directory named ``output`` next to the
+sketch source file. The output directory can be overridden with the ``--output-dir`` option, or
+with the ``VSK_OUTPUT_DIR`` environment variable.
 
 Exporting SVG with ``vsk save``
 -------------------------------

--- a/vsketch_cli/cli.py
+++ b/vsketch_cli/cli.py
@@ -102,7 +102,7 @@ By default, the new project is based on the official template located here:
     https://github.com/abey79/cookiecutter-vsketch-sketch
 
 You can provide an alternative template address with the --template option.
- 
+
 Most options can use environment variables to set their default values. For example, the
 default template can be set with the VSK_TEMPLATE variable and the default page size with the
 VSK_PAGE_SIZE variable.
@@ -180,7 +180,18 @@ def _parse_seed(seed: str) -> Tuple[int, int]:
     envvar="VSK_FULLSCREEN",
     help="Display the viewer fullscreen on the second screen if available.",
 )
-def run(target: Optional[str], editor: Optional[str], fullscreen: bool) -> None:
+@click.option(
+    "--output-dir",
+    envvar="VSK_OUTPUT_DIR",
+    type=click.Path(path_type=pathlib.Path, file_okay=False, dir_okay=True),
+    help="Directory to save liked plots. If not provided, defaults to a directory called 'output' next to the sketch source file.",
+)
+def run(
+    target: Optional[str],
+    editor: Optional[str],
+    fullscreen: bool,
+    output_dir: Optional[pathlib.Path],
+) -> None:
     """Execute, display and monitor changes on a sketch.
 
     This command loads a sketch and opens an interactive viewer display the result. The viewer
@@ -210,7 +221,7 @@ def run(target: Optional[str], editor: Optional[str], fullscreen: bool) -> None:
     if editor is not None and editor != "":
         os.system(f"{editor} {path}")
 
-    show(str(path), second_screen=fullscreen)
+    show(path, output_dir, second_screen=fullscreen)
 
 
 @dataclasses.dataclass()

--- a/vsketch_cli/gui.py
+++ b/vsketch_cli/gui.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
@@ -7,7 +8,9 @@ from vpype_viewer.qtviewer.utils import set_sigint_handler
 from .sketch_viewer import SketchViewer
 
 
-def show(path: str, second_screen: bool = False) -> int:
+def show(
+    path: pathlib.Path, output_dir: Optional[pathlib.Path], second_screen: bool = False
+) -> int:
     if not QApplication.instance():
         app = QApplication()
     else:
@@ -15,7 +18,7 @@ def show(path: str, second_screen: bool = False) -> int:
     app.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
 
     # create widget
-    widget = SketchViewer(pathlib.Path(path))
+    widget = SketchViewer(path, output_dir)
 
     # handle window sizing
     screens = app.screens()
@@ -43,4 +46,8 @@ def show(path: str, second_screen: bool = False) -> int:
 
 
 if __name__ == "__main__":
-    show("/Users/hhip/src/vsketch/examples/simple_sketch/sketch.py", second_screen=True)
+    show(
+        pathlib.Path("/Users/hhip/src/vsketch/examples/simple_sketch/sketch.py"),
+        output_dir=None,
+        second_screen=True,
+    )

--- a/vsketch_cli/sketch_viewer.py
+++ b/vsketch_cli/sketch_viewer.py
@@ -59,12 +59,17 @@ class SideBarWidget(QWidget):
 
 
 class SketchViewer(vpype_viewer.QtViewer):
-    def __init__(self, path: pathlib.Path, *args: Any, **kwargs: Any):
+    def __init__(
+        self, path: pathlib.Path, output_dir: Optional[pathlib.Path], *args: Any, **kwargs: Any
+    ):
         super().__init__(*args, **kwargs)
 
         self._sketch_class: Optional[Type[vsketch.SketchClass]] = None
         self._sketch: Optional[vsketch.SketchClass] = None
         self._path = path.resolve(strict=True)  # make sure the path has no symlink
+        self._output_dir = (
+            output_dir if output_dir is not None else self._path.parent / "output"
+        )
         self._param_set: Dict[str, Any] = {}
         self._seed: Optional[int] = None
         self._thread: Optional[QThread] = None
@@ -136,9 +141,10 @@ class SketchViewer(vpype_viewer.QtViewer):
             return
 
         base_name = canonical_name(self._path)
-        path = find_unique_path(
-            base_name + "_liked.svg", self._path.parent / "output", always_number=True
-        )
+
+        # Create output directory if it doesn't already exist
+        self._output_dir.mkdir(exist_ok=True)
+        path = find_unique_path(base_name + "_liked.svg", self._output_dir, always_number=True)
 
         self._sketch.ensure_finalized()
 


### PR DESCRIPTION
This commit adds the ability to configure the output SVG directory when using `vsk run`, via a new command-line option `--output-dir` (or, equivalently, the `VSK_OUTPUT_DIR` environment variable).

This provides more flexibility for users using vsketch as a library with multiple sketches, such as if a user wants to keep saved SVGs all in a common directory regardless of the directory structure of the plot source files themselves.

If no option is provided, retains the previous default behavior, which is to save the output in a directory called `output/` next to the sketch source file.

#### Testing

Tested using the following commands:

```bash
$ cd examples

# Test default behavior
$ vsk run noise_bezier/
# Click "like"
$ ls noise_bezier/output/
noise_bezier_liked_1.svg

# Test command line parameter
$ vsk run --output-dir=../my_output noise_bezier/
# Click "like"
$ ls ../my_output/
noise_bezier_liked_1.svg

# Test environment variable
$ env VSK_OUTPUT_DIR=../my_output2 vsk run noise_bezier/
# Click "like"
$ ls ../my_output/
noise_bezier_liked_2.svg
```

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error

```bash
$ mypy vsketch_cli/
Success: no issues found in 10 source files
```

- [x] tests added/updated and `pytest --runslow` succeeds

```bash
$ just test
...
============================================================= 340 passed, 8 skipped in 3.33s =============================================================
```

- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)

```bash
$ just docs-build
...
writing output... [100%] overview
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in docs/_build.
```

- [x] examples added/updated

N/A, `examples/` code is unaffected, this is purely a CLI change.

- [x] code formatting ok (`black` and `isort`)

```bash
$ black .
...
All done! ✨ 🍰 ✨
75 files left unchanged.
```

```bash
$ isort vsketch_cli/
# No changes
```