### PR TITLE
Fix bug in Param.set_value_with_validation when bounds are 0.0

### DIFF
--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1,0 +1,24 @@
+import pytest
+
+from vsketch.sketch_class import Param
+
+
+@pytest.mark.parametrize(
+    ["initial_value", "min_value", "max_value", "set_value"],
+    [
+        [0.0, -5.0, 5.0, 0.0],  # set equal to initial value
+        [0.0, -5.0, 5.0, 0.5],  # set within bounds
+        [0.0, -5.0, 5.0, -10.0],  # set below min_value
+        [0.0, -5.0, 5.0, 10.0],  # set above max_value
+        [0.0, 0.0, 5.0, -10.0],  # set below min_value = 0.0
+        [0.0, -5.0, 0.0, 10.0],  # set above max_value = 0.0
+    ],
+)
+def test_float_param_bounds(initial_value, min_value, max_value, set_value):
+    """
+    Tests that sketch_class.Param.set_value_with_validation respects min_value and max_value, and
+    clamps values to be within that range.
+    """
+    float_param = Param(initial_value, min_value=min_value, max_value=max_value)
+    float_param.set_value_with_validation(set_value)
+    assert float_param.value == min(max_value, max(min_value, set_value))

--- a/vsketch/sketch_class.py
+++ b/vsketch/sketch_class.py
@@ -231,10 +231,10 @@ class Param(Generic[_T]):
         if self.choices and value not in self.choices:
             return False
 
-        if self.min:
+        if self.min is not None:
             value = max(self.min, value)  # type: ignore
 
-        if self.max:
+        if self.max is not None:
             value = min(self.max, value)  # type: ignore
 
         self.value = value


### PR DESCRIPTION
`Param.set_value_with_validation` assigns a value to to a parameter, and checks that the value attempting to set is the right type. In addition, if the parameter has a defined min and/or max value, `set_value_with_validation` clamps the value to respect the defined bounds.

As an example, given a param defined with
`param = Param(0.0, min_value=-5.0, max_value=5.0)`, calling `param.set_value_with_validation(-10.0)` will result in the parameter value becoming -5.0, since that's the closest value that respects the `min_value` of `-5.0.

The logic that implements this behavior is implemented with:

```python
if self.min:
    value = max(self.min, value)

if self.max:
    value = min(self.max, value)
```

But this code does not have the expected behavior when either `self.min` or `self.max` are `0.0`. `0.0` (and `-0.0` for that matter) is considered "falsey" in Python (`bool(0.0) == False`), and so the branch won't be taken. That means a `min_value` or `max_value` of `0.0` won't be respected, e.g., if you have `param = Param(0.0, min_value=0.0, max_value=5.0)`, then `param.set_value_with_validation(-10.0)` will actually set the value to `-10.0`.

It is hard to trigger this case to happen using the Qt-based renderer, since parameter values seem only to come from either the `FloatParamWidget` (which sets the bounds of the parent `QDoubleSpinBox` independently of the `min/max_value` of the underlying `Param`), or from saved configurations which are loaded from disk.

But fixing this issue prevents subtle bugs if params come from other places in the future, and makes the behavior consistent with non-zero bounds.

This commit fixes the issue by changing the checks to evaluate the branch whenever the value is not None, not just when the value is "truthy" (e.g., `if self.min is not None:` instead of `if self.min:`). This commit also adds a new unit test file (`test_param.py`) with unit tests that fail without the fix and pass after.

#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest --runslow` succeeds
- [x] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [x] examples added/updated
- [x] code formatting ok (`black` and `isort`)
