### PR TITLE
Properly display and export the pen widths set by the sketch

### DIFF
--- a/vsketch/sketch_class.py
+++ b/vsketch/sketch_class.py
@@ -33,6 +33,12 @@ class SketchClass:
     def execute_draw(self) -> None:
         self.draw(self._vsk)
 
+        # apply pen widths to the document's metadata
+        for lid, layer in self._vsk.document.layers.items():
+            pen_width = self._vsk.getPenWidth(lid)
+            if pen_width is not None:
+                layer.set_property(vp.METADATA_FIELD_PEN_WIDTH, pen_width)
+
     def ensure_finalized(self) -> None:
         if self._finalized:
             return

--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -325,6 +325,21 @@ class Vsketch:
         else:
             self._default_pen_width = w
 
+    def getPenWidth(self, layer: int | None) -> float | None:
+        """Get the pen width for a given layer.
+
+        Args:
+            layer: layer ID (or None for default pen width)
+
+        Returns:
+            the pen width (or `None` if not defined)
+        """
+
+        if layer is None:
+            return self._default_pen_width
+
+        return self._pen_width.get(layer, self._default_pen_width)
+
     @property
     def strokePenWidth(self) -> float:
         """Returns the pen width to be used for stroke, or 0 in :func:`noStroke` mode.


### PR DESCRIPTION
#### Description

* Fixes #416
* Related to #205

Before:

<img width="513" alt="image" src="https://github.com/abey79/vsketch/assets/49431240/e6e65e23-0a1d-4706-9ba3-24ea4e22d35a">


<br/>
<br/>

After:

<img width="476" alt="image" src="https://github.com/abey79/vsketch/assets/49431240/20302cc1-ddf0-4c6c-8d16-39060fca52ff">


#### Checklist

- [x] feature/fix implemented
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [x] code formatting ok (`black` and `isort`)
