### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You'll find all the SVG file in the project's `output` subdirectory:
 
 Next steps:
 * Use `vsk` integrated help to learn about the all the possibilities (`vsk --help`).
-* Learn the vsketch API on the documentation's [overview](https://vsketch.readthedocs.io/en/latest/overview.html) and [reference](https://vsketch.readthedocs.io/en/latest/reference.html) pages.
+* Learn the vsketch API on the documentation's [overview](https://vsketch.readthedocs.io/en/latest/overview.html) and [reference](https://vsketch.readthedocs.io/en/latest/autoapi/vsketch/index.html) pages.
 
 
 ## Acknowledgments


### PR DESCRIPTION
#### Description

Reference API link to readthedocs has changed. Old link is 404.
Didn't update Changelog since it's just a link update in readme.

#### Checklist

- [ ] feature/fix implemented
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
- [ ] updated `CHANGELOG.md`
